### PR TITLE
feat: Adds possibility of running DU in the simulation mode

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -67,6 +67,10 @@ config:
       type: int
       default: 1
       description: Tracking Area Code
+    simulation-mode:
+      type: boolean
+      default: false
+      description: Run DU in simulation mode
 
 parts:
   charm:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -70,7 +70,9 @@ config:
     simulation-mode:
       type: boolean
       default: false
-      description: Run DU in simulation mode
+      description: |
+        Run DU in simulation mode.
+        In the simulation mode, the DU emulates the Radio Unit (RU) which, in real deployment, would have been a physical device connected to the DU. Simulation mode has been designed to work with the OAI RAN NR UE (a simulated 5G User Equipment).
 
 parts:
   charm:

--- a/src/charm_config.py
+++ b/src/charm_config.py
@@ -49,6 +49,7 @@ class DUConfig(BaseModel):  # pylint: disable=too-few-public-methods
     mnc: StrictStr = Field(pattern=r"^\d{2}$")
     sst: int = Field(ge=1, le=4)
     tac: int = Field(ge=1, le=16777215)
+    simulation_mode: bool = False
 
 
 @dataclasses.dataclass
@@ -62,6 +63,7 @@ class CharmConfig:
         mnc: Mobile Network code
         sst: Slice Service Type
         tac: Tracking Area Code
+        simulation_mode: Run DU in simulation mode
     """
 
     f1_interface_name: StrictStr
@@ -70,6 +72,7 @@ class CharmConfig:
     mnc: StrictStr
     sst: int
     tac: int
+    simulation_mode: bool
 
     def __init__(self, *, du_config: DUConfig):
         """Initialize a new instance of the CharmConfig class.
@@ -83,6 +86,7 @@ class CharmConfig:
         self.mnc = du_config.mnc
         self.sst = du_config.sst
         self.tac = du_config.tac
+        self.simulation_mode = du_config.simulation_mode
 
     @classmethod
     def from_charm(

--- a/src/templates/du.conf.j2
+++ b/src/templates/du.conf.j2
@@ -142,14 +142,6 @@ THREAD_STRUCT =
     }
 );
 
-rfsimulator: {
-    serveraddr = "server";
-    serverport = 4043;
-    options    = ();
-    modelname  = "AWGN";
-    IQfile     = "/tmp/rfsimulator.iqs"
-}
-
 log_config: {
     global_log_options = "level,nocolor,time";
     global_log_level   = "info";
@@ -159,3 +151,12 @@ log_config: {
     rlc_log_level      = "info";
     f1ap_log_level     = "info";
 };
+{% if simulation_mode %}
+rfsimulator: {
+    serveraddr = "server";
+    serverport = 4043;
+    options    = ();
+    modelname  = "AWGN";
+    IQfile     = "/tmp/rfsimulator.iqs"
+};
+{% endif %}

--- a/tests/unit/resources/expected_rfsim_mode_config.conf
+++ b/tests/unit/resources/expected_rfsim_mode_config.conf
@@ -151,3 +151,11 @@ log_config: {
     rlc_log_level      = "info";
     f1ap_log_level     = "info";
 };
+
+rfsimulator: {
+    serveraddr = "server";
+    serverport = 4043;
+    options    = ();
+    modelname  = "AWGN";
+    IQfile     = "/tmp/rfsimulator.iqs"
+};

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -348,7 +348,7 @@ class TestCharm:
         updated_plan = self.harness.get_container_pebble_plan(WORKLOAD_CONTAINER_NAME).to_dict()
         assert expected_pebble_plan == updated_plan
 
-    def test_given_charm_configuration_is_done_when_simulation_mode_config_changed_to_true_then_service_startup_command_container_rfsim_flag(
+    def test_given_charm_configuration_is_done_when_simulation_mode_config_changed_to_true_then_service_startup_command_container_rfsim_flag(  # noqa: E501
         self,
     ):
         expected_pebble_plan = {

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ commands =
 [testenv:lint]
 description = Check code against coding style standards
 commands =
-    codespell {tox_root}
+    codespell -L UE {tox_root}
     ruff check {[vars]all_path}
 
 [testenv:static]


### PR DESCRIPTION
# Description

This PR allows for running the DU in the simulation mode.
Simulation mode should be used for automated tests and can be enabled by setting the `simulation-mode` charm config option to `True`.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library