### PR TITLE
fix: Use 3/4 sampling with B210

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -368,7 +368,7 @@ class OAIRANDUOperator(CharmBase):
         rfsim_switch = ""
         if self._charm_config.simulation_mode:
             rfsim_switch = "--rfsim"
-        return f"/opt/oai-gnb/bin/nr-softmodem -O {BASE_CONFIG_PATH}/{CONFIG_FILE_NAME} --sa {rfsim_switch}"  # noqa: E501
+        return f"/opt/oai-gnb/bin/nr-softmodem -O {BASE_CONFIG_PATH}/{CONFIG_FILE_NAME} -E --sa {rfsim_switch}"  # noqa: E501
 
     @property
     def _du_environment_variables(self) -> dict:

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -236,7 +236,7 @@ class TestCharmConfigure(DUFixtures):
                             "du": {
                                 "startup": "enabled",
                                 "override": "replace",
-                                "command": "/opt/oai-gnb/bin/nr-softmodem -O /tmp/conf/du.conf --sa ",  # noqa: E501
+                                "command": "/opt/oai-gnb/bin/nr-softmodem -O /tmp/conf/du.conf -E --sa ",  # noqa: E501
                                 "environment": {"TZ": "UTC"},
                             }
                         }
@@ -285,7 +285,7 @@ class TestCharmConfigure(DUFixtures):
                             "du": {
                                 "startup": "enabled",
                                 "override": "replace",
-                                "command": "/opt/oai-gnb/bin/nr-softmodem -O /tmp/conf/du.conf --sa --rfsim",  # noqa: E501
+                                "command": "/opt/oai-gnb/bin/nr-softmodem -O /tmp/conf/du.conf -E --sa --rfsim",  # noqa: E501
                                 "environment": {"TZ": "UTC"},
                             }
                         }


### PR DESCRIPTION
When running the DU with a B210, the error `Error: unknown sampling rate 61440000.000000` appeared in the logs. After some quick search, it turns out that this series of radio needs to be run at 3/4 sampling, with the `-E` command-line switch.

This commit hard codes this switch in the charm, as we are only currently testing with the B210 radio. This will need to be exposed as a configuration item in the future, but the way to do so will need proper design.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library