### PR TITLE
feat: Expose simulator port when running in simulation mode

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -100,6 +100,7 @@ class OAIRANDUOperator(CharmBase):
             ports=[
                 ServicePort(name="f1c", port=38472, protocol="SCTP"),
                 ServicePort(name="f1u", port=self._charm_config.f1_port, protocol="UDP"),
+                ServicePort(name="rfsim", port=4043, protocol="TCP"),
             ],
         )
 


### PR DESCRIPTION
# Description

This exposes the simulator port on the Service when running in simulation mode. There are currently no tests for this. Integration tests with the UE would be a good place to test this in the future.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library