### PR TITLE
feat: Implement fiveg_rfsim interface provider side

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -35,6 +35,10 @@ resources:
     description: Container image for the OAI RAN Distributed Unit (DU).
     upstream-source: ghcr.io/canonical/oai-ran-du:2.1.1
 
+provides:
+  fiveg_rfsim:
+    interface: fiveg_rfsim
+
 requires:
   fiveg_f1:
     interface: fiveg_f1

--- a/lib/charms/oai_ran_du_k8s/v0/fiveg_rfsim.py
+++ b/lib/charms/oai_ran_du_k8s/v0/fiveg_rfsim.py
@@ -1,0 +1,273 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Library for the `fiveg_rfsim` relation.
+
+This library contains the Requires and Provides classes for handling the `fiveg_rfsim` interface.
+
+The purpose of this library is to relate two charms to pass the RF SIM address.
+In the Telco world this will typically be charms implementing
+the DU (Distributed Unit) and the UE (User equipment).
+
+## Getting Started
+From a charm directory, fetch the library using `charmcraft`:
+
+```shell
+charmcraft fetch-lib charms.oai_ran_du_k8s.v0.fiveg_rfsim
+```
+
+Add the following libraries to the charm's `requirements.txt` file:
+- pydantic
+- pytest-interface-tester
+
+### Provider charm
+The provider charm is the one providing the information about RF SIM address.
+Typically, this will be the DU charm.
+
+Example:
+```python
+
+from ops.charm import CharmBase, RelationJoinedEvent
+from ops.main import main
+
+from charms.oai_ran_du_k8s.v0.fiveg_rfsim import RFSIMProvides
+
+
+class DummyFivegRFSIMProviderCharm(CharmBase):
+
+    RFSIM_ADDRESS = "192.168.70.130:4043"
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.rfsim_provider = RFSIMProvides(self, "fiveg_rfsim")
+        self.framework.observe(
+            self.on.fiveg_rfsim_relation_joined, self._on_fiveg_rfsim_relation_joined
+        )
+
+    def _on_fiveg_rfsim_relation_joined(self, event: RelationJoinedEvent):
+        if self.unit.is_leader():
+            self.rfsim_provider.set_rfsim_information(
+                rfsim_address=self.RFSIM_ADDRESS,
+            )
+
+
+if __name__ == "__main__":
+    main(DummyFivegRFSIMProviderCharm)
+```
+
+### Requirer charm
+The requirer charm is the one requiring the RF simulator information.
+Typically, this will be the UE charm.
+
+Example:
+```python
+
+from ops.charm import CharmBase
+from ops.main import main
+
+from charms.oai_ran_du_k8s.v0.fiveg_rfsim import FivegRFSIMInformationAvailableEvent, RFSIMRequires
+
+logger = logging.getLogger(__name__)
+
+
+class DummyFivegRFSIMRequires(CharmBase):
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.rfsim_requirer = RFSIMRequires(self, "fiveg_rfsim")
+        self.framework.observe(
+            self.rfsim_requirer.on.fiveg_rfsim_provider_available, self._on_rfsim_information_available
+        )
+
+    def _on_rfsim_information_available(self, event: FivegRFSIMInformationAvailableEvent):
+        provider_rfsim_address = event.rfsim_address
+        <do something with the rfsim address here>
+
+
+if __name__ == "__main__":
+    main(DummyFivegRFSIMRequires)
+```
+
+"""
+
+
+import logging
+from typing import Any, Dict, Optional
+
+from interface_tester.schema_base import DataBagSchema
+from ops.charm import CharmBase, CharmEvents, RelationChangedEvent
+from ops.framework import EventBase, EventSource, Handle, Object
+from ops.model import Relation
+from pydantic import BaseModel, Field, ValidationError
+
+
+# The unique Charmhub library identifier, never change it
+LIBID = "e5d421b1edce4e8b8b3632d55869117c"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+
+logger = logging.getLogger(__name__)
+
+
+class FivegRFSIMProviderAppData(BaseModel):
+    """Provider app data for fiveg_rfsim."""
+
+    rfsim_address: str = Field(
+        description="RF simulator service address of DU including DU pod ip and port",
+        examples=["192.168.70.130:4043"],
+    )
+
+
+class ProviderSchema(DataBagSchema):
+    """Provider schema for the fiveg_rfsim interface."""
+
+    app: FivegRFSIMProviderAppData
+
+
+def provider_data_is_valid(data: Dict[str, Any]) -> bool:
+    """Return whether the provider data is valid.
+
+    Args:
+        data (dict): Data to be validated.
+
+    Returns:
+        bool: True if data is valid, False otherwise.
+    """
+    try:
+        ProviderSchema(app=data)
+        return True
+    except ValidationError as e:
+        logger.error("Invalid data: %s", e)
+        return False
+
+
+class FivegRFSIMInformationAvailableEvent(EventBase):
+    """Charm event emitted when the RFSIM provider info is available.
+
+    The event carries the RFSIM provider's address.
+    """
+
+    def __init__(self, handle: Handle, rfsim_address: str):
+        """Init."""
+        super().__init__(handle)
+        self.rfsim_address = rfsim_address
+
+    def snapshot(self) -> dict:
+        """Return snapshot."""
+        return {
+            "rfsim_address": self.rfsim_address,
+        }
+
+    def restore(self, snapshot: dict) -> None:
+        """Restores snapshot."""
+        self.rfsim_address = snapshot["rfsim_address"]
+
+
+class FivegRFSIMRequirerCharmEvents(CharmEvents):
+    """The event that the RFSIM requirer charm can leverage."""
+
+    fiveg_rfsim_provider_available = EventSource(FivegRFSIMInformationAvailableEvent)
+
+
+class FivegRFSIMError(Exception):
+    """Custom error class for the `fiveg_rfsim` library."""
+
+    def __init__(self, message: str):
+        self.message = message
+        super().__init__(self.message)
+
+
+class RFSIMProvides(Object):
+    """Class to be instantiated by the charm providing relation using the `fiveg_rfsim` interface."""
+
+    def __init__(self, charm: CharmBase, relation_name: str):
+        """Init."""
+        super().__init__(charm, relation_name)
+        self.relation_name = relation_name
+        self.charm = charm
+
+    def set_rfsim_information(self, rfsim_address: str) -> None:
+        """Push the information about the RFSIM interface in the application relation data.
+
+        Args:
+            rfsim_address (str): rfsim service address including the pod ip and port number.
+        """
+        if not self.charm.unit.is_leader():
+            raise FivegRFSIMError("Unit must be leader to set application relation data.")
+        relations = self.model.relations[self.relation_name]
+        if not relations:
+            raise FivegRFSIMError(f"Relation {self.relation_name} not created yet.")
+        if not provider_data_is_valid({"rfsim_address": rfsim_address}):
+            raise FivegRFSIMError("Invalid relation data")
+        for relation in relations:
+            relation.data[self.charm.app].update(
+                {
+                    "rfsim_address": rfsim_address,
+                }
+            )
+
+
+class RFSIMRequires(Object):
+    """Class to be instantiated by the charm requiring relation using the `fiveg_rfsim` interface."""
+
+    on = FivegRFSIMRequirerCharmEvents()
+
+    def __init__(self, charm: CharmBase, relation_name: str):
+        """Init."""
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.relation_name = relation_name
+        self.framework.observe(charm.on[relation_name].relation_changed, self._on_relation_changed)
+
+    def _on_relation_changed(self, event: RelationChangedEvent) -> None:
+        """Handle relation changed event.
+
+        Args:
+            event (RelationChangedEvent): Juju event.
+        """
+        if remote_app_relation_data := self._get_remote_app_relation_data(event.relation):
+            self.on.fiveg_rfsim_provider_available.emit(
+                rfsim_address=remote_app_relation_data["rfsim_address"],
+            )
+
+    @property
+    def rfsim_address(self) -> Optional[str]:
+        """Return address of the RFSIM.
+
+        Returns:
+            str: rfsim address including pod ip and port number.
+        """
+        if remote_app_relation_data := self._get_remote_app_relation_data():
+            return remote_app_relation_data.get("rfsim_address")
+        return None
+
+    def _get_remote_app_relation_data(
+        self, relation: Optional[Relation] = None
+    ) -> Optional[Dict[str, str]]:
+        """Get relation data for the remote application.
+
+        Args:
+            relation: Juju relation object (optional).
+
+        Returns:
+            Dict: Relation data for the remote application
+            or None if the relation data is invalid.
+        """
+        relation = relation or self.model.get_relation(self.relation_name)
+        if not relation:
+            logger.error("No relation: %s", self.relation_name)
+            return None
+        if not relation.app:
+            logger.warning("No remote application in relation: %s", self.relation_name)
+            return None
+        remote_app_relation_data = dict(relation.data[relation.app])
+        if not provider_data_is_valid(remote_app_relation_data):
+            logger.error("Invalid relation data: %s", remote_app_relation_data)
+            return None
+        return remote_app_relation_data

--- a/src/charm.py
+++ b/src/charm.py
@@ -98,6 +98,7 @@ class OAIRANDUOperator(CharmBase):
         self.framework.observe(self.on.update_status, self._configure)
         self.framework.observe(self.on.config_changed, self._configure)
         self.framework.observe(self.on.du_pebble_ready, self._configure)
+        self.framework.observe(self._f1_requirer.on.fiveg_f1_provider_available, self._configure)
         self.framework.observe(self.on.fiveg_rfsim_relation_joined, self._configure)
         self.framework.observe(self.on.remove, self._on_remove)
 
@@ -251,8 +252,6 @@ class OAIRANDUOperator(CharmBase):
         if not self._relation_created(RFSIM_RELATION_NAME):
             return
         if not self._du_service_is_running():
-            return
-        if not _get_pod_ip():
             return
         if not self._get_rfsim_address():
             return

--- a/src/charm.py
+++ b/src/charm.py
@@ -17,6 +17,7 @@ from charms.kubernetes_charm_libraries.v0.multus import (
 )
 from charms.loki_k8s.v1.loki_push_api import LogForwarder
 from charms.oai_ran_cu_k8s.v0.fiveg_f1 import F1Requires
+from charms.oai_ran_du_k8s.v0.fiveg_rfsim import RFSIMProvides
 from charms.observability_libs.v1.kubernetes_service_patch import (
     KubernetesServicePatch,
 )
@@ -27,6 +28,7 @@ from ops import (
     ActiveStatus,
     BlockedStatus,
     CollectStatusEvent,
+    ModelError,
     WaitingStatus,
 )
 from ops.charm import CharmBase
@@ -41,8 +43,10 @@ logger = logging.getLogger(__name__)
 BASE_CONFIG_PATH = "/tmp/conf"
 CONFIG_FILE_NAME = "du.conf"
 F1_RELATION_NAME = "fiveg_f1"
+RFSIM_RELATION_NAME = "fiveg_rfsim"
 LOGGING_RELATION_NAME = "logging"
 WORKLOAD_VERSION_FILE_NAME = "/etc/workload-version"
+RFSIM_PORT = 4043
 
 
 class OAIRANDUOperator(CharmBase):
@@ -56,6 +60,7 @@ class OAIRANDUOperator(CharmBase):
         self._container_name = self._service_name = "du"
         self._container = self.unit.get_container(self._container_name)
         self._f1_requirer = F1Requires(self, F1_RELATION_NAME)
+        self.rfsim_provider = RFSIMProvides(self, RFSIM_RELATION_NAME)
         self._logging = LogForwarder(charm=self, relation_name=LOGGING_RELATION_NAME)
         self._du_security_context = DUSecurityContext(
             namespace=self.model.name,
@@ -93,7 +98,7 @@ class OAIRANDUOperator(CharmBase):
         self.framework.observe(self.on.update_status, self._configure)
         self.framework.observe(self.on.config_changed, self._configure)
         self.framework.observe(self.on.du_pebble_ready, self._configure)
-        self.framework.observe(self._f1_requirer.on.fiveg_f1_provider_available, self._configure)
+        self.framework.observe(self.on.fiveg_rfsim_relation_joined, self._configure)
         self.framework.observe(self.on.remove, self._on_remove)
 
     def _on_collect_unit_status(self, event: CollectStatusEvent):  # noqa C901
@@ -195,6 +200,7 @@ class OAIRANDUOperator(CharmBase):
         self._configure_pebble(restart=service_restart_required)
 
         self._update_fiveg_f1_relation_data()
+        self._set_fiveg_rfsim_relation_data()
 
     def _on_remove(self, _) -> None:
         """Handle the remove event."""
@@ -237,6 +243,46 @@ class OAIRANDUOperator(CharmBase):
             bool: Whether the relation was created.
         """
         return bool(self.model.relations.get(relation_name))
+
+    def _set_fiveg_rfsim_relation_data(self) -> None:
+        """Set rfsim information for the fiveg_rfsim relation."""
+        if not self.unit.is_leader():
+            return
+        if not self._relation_created(RFSIM_RELATION_NAME):
+            return
+        if not self._du_service_is_running():
+            return
+        if not _get_pod_ip():
+            return
+        if not self._get_rfsim_address():
+            return
+        self.rfsim_provider.set_rfsim_information(self._get_rfsim_address())
+
+    @staticmethod
+    def _get_rfsim_address() -> str:
+        """Return the RFSIM service address.
+
+        Returns:
+            str/None: Pod ip address together with RFSIM service port
+            if pod is running else None
+        """
+        if _get_pod_ip():
+            return f"{_get_pod_ip()}:{RFSIM_PORT}"
+        return ""
+
+    def _du_service_is_running(self) -> bool:
+        """Return whether the DU service is running.
+
+        Returns:
+            bool: Whether the DU service is running.
+        """
+        if not self._container.can_connect():
+            return False
+        try:
+            service = self._container.get_service(self._service_name)
+        except ModelError:
+            return False
+        return service.is_running()
 
     def _generate_du_config(self) -> str:
         if not self._f1_requirer.f1_ip_address:

--- a/tests/unit/fixtures.py
+++ b/tests/unit/fixtures.py
@@ -21,6 +21,9 @@ class DUFixtures:
     )
     patcher_f1_requires_f1_port = patch("charm.F1Requires.f1_port", new_callable=PropertyMock)
     patcher_f1_requires_set_f1_information = patch("charm.F1Requires.set_f1_information")
+    patcher_rfsim_provides_set_rfsim_information = patch(
+        "charm.RFSIMProvides.set_rfsim_information"
+    )
 
     @pytest.fixture(autouse=True)
     def setUp(self, request):
@@ -32,6 +35,9 @@ class DUFixtures:
         self.mock_f1_requires_f1_ip_address = DUFixtures.patcher_f1_requires_f1_ip_address.start()
         self.mock_f1_requires_f1_port = DUFixtures.patcher_f1_requires_f1_port.start()
         self.mock_f1_set_information = DUFixtures.patcher_f1_requires_set_f1_information.start()
+        self.mock_rfsim_set_information = (
+            DUFixtures.patcher_rfsim_provides_set_rfsim_information.start()
+        )
         yield
         request.addfinalizer(self.tearDown)
 

--- a/tests/unit/lib/charms/oai_ran_du/v0/test_charms/test_provider_charm/src/charm.py
+++ b/tests/unit/lib/charms/oai_ran_du/v0/test_charms/test_provider_charm/src/charm.py
@@ -1,0 +1,32 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+
+from ops.charm import ActionEvent, CharmBase
+from ops.main import main
+
+from lib.charms.oai_ran_du_k8s.v0.fiveg_rfsim import RFSIMProvides
+
+logger = logging.getLogger(__name__)
+
+
+class DummyFivegRFSIMProviderCharm(CharmBase):
+    """Dummy charm implementing the provider side of the fiveg_rfsim interface."""
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.rfsim_provider = RFSIMProvides(self, "fiveg_rfsim")
+        self.framework.observe(
+            self.on.set_rfsim_information_action, self._on_set_rfsim_information_action
+        )
+
+    def _on_set_rfsim_information_action(self, event: ActionEvent):
+        rfsim_address = event.params.get("rfsim_address", "")
+        self.rfsim_provider.set_rfsim_information(
+            rfsim_address=rfsim_address,
+        )
+
+
+if __name__ == "__main__":
+    main(DummyFivegRFSIMProviderCharm)

--- a/tests/unit/lib/charms/oai_ran_du/v0/test_charms/test_requirer_charm/src/charm.py
+++ b/tests/unit/lib/charms/oai_ran_du/v0/test_charms/test_requirer_charm/src/charm.py
@@ -1,0 +1,31 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from ops.charm import ActionEvent, CharmBase
+from ops.main import main
+
+from lib.charms.oai_ran_du_k8s.v0.fiveg_rfsim import (
+    RFSIMRequires,
+)
+
+
+class DummyFivegRFSIMRequires(CharmBase):
+    """Dummy charm implementing the requirer side of the fiveg_rfsim interface."""
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.rfsim_requirer = RFSIMRequires(self, "fiveg_rfsim")
+        self.framework.observe(
+            self.on.get_rfsim_information_action, self._on_get_rfsim_information_action
+        )
+
+    def _on_get_rfsim_information_action(self, event: ActionEvent):
+        event.set_results(
+            results={
+                "rfsim-address": self.rfsim_requirer.rfsim_address,
+            }
+        )
+
+
+if __name__ == "__main__":
+    main(DummyFivegRFSIMRequires)

--- a/tests/unit/lib/charms/oai_ran_du/v0/test_fiveg_rfsim_provider_interface.py
+++ b/tests/unit/lib/charms/oai_ran_du/v0/test_fiveg_rfsim_provider_interface.py
@@ -1,0 +1,102 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from unittest.mock import patch
+
+import pytest
+import scenario
+
+from tests.unit.lib.charms.oai_ran_du.v0.test_charms.test_provider_charm.src.charm import (
+    DummyFivegRFSIMProviderCharm,
+)
+
+
+class TestFivegRFSIMProvides:
+    @pytest.fixture(autouse=True)
+    def setUp(self, request):
+        yield
+        request.addfinalizer(self.tearDown)
+
+    def tearDown(self) -> None:
+        patch.stopall()
+
+    @pytest.fixture(autouse=True)
+    def context(self):
+        self.ctx = scenario.Context(
+            charm_type=DummyFivegRFSIMProviderCharm,
+            meta={
+                "name": "rfsim-provider-charm",
+                "provides": {"fiveg_rfsim": {"interface": "fiveg_rfsim"}},
+            },
+            actions={
+                "set-rfsim-information": {"params": {"rfsim_address": {"type": "string"}}},
+            },
+        )
+
+    def test_given_valid_rfsim_interface_data_when_set_rfsim_information_then_rfsim_address_is_pushed_to_the_relation_databag(  # noqa: E501
+        self,
+    ):
+        fiveg_rfsim_relation = scenario.Relation(
+            endpoint="fiveg_rfsim",
+            interface="fiveg_rfsim",
+        )
+        state_in = scenario.State(
+            relations=[fiveg_rfsim_relation],
+            leader=True,
+        )
+
+        action = scenario.Action(
+            name="set-rfsim-information",
+            params={
+                "rfsim_address": "1.2.3.4:4043",
+            },
+        )
+        action_output = self.ctx.run_action(action, state_in)
+
+        assert action_output.state.relations[0].local_app_data["rfsim_address"] == "1.2.3.4:4043"
+
+    def test_given_invalid_rfsim_address_when_set_rfsim_information_then_error_is_raised(self):
+        fiveg_rfsim_relation = scenario.Relation(
+            endpoint="fiveg_rfsim",
+            interface="fiveg_rfsim",
+        )
+        state_in = scenario.State(
+            relations=[fiveg_rfsim_relation],
+            leader=True,
+        )
+
+        action = scenario.Action(
+            name="set-rfsim-information",
+            params={
+                "rfsim_address": 1111,
+            },
+        )
+
+        with pytest.raises(Exception) as e:
+            self.ctx.run_action(action, state_in)
+
+        assert "Inconsistent scenario" in str(e.value)
+
+    def test_given_unit_is_not_leader_when_fiveg_rfsim_relation_joined_then_data_is_not_in_application_databag(  # noqa: E501
+        self,
+    ):
+        fiveg_rfsim_relation = scenario.Relation(
+            endpoint="fiveg_rfsim",
+            interface="fiveg_rfsim",
+        )
+        state_in = scenario.State(
+            leader=False,
+            relations=[fiveg_rfsim_relation],
+        )
+
+        action = scenario.Action(
+            name="set-rfsim-information",
+            params={
+                "rfsim_address": "1.2.3.4:4043",
+            },
+        )
+
+        with pytest.raises(Exception) as e:
+            self.ctx.run_action(action, state_in)
+
+        assert "Unit must be leader" in str(e.value)

--- a/tests/unit/lib/charms/oai_ran_du/v0/test_fiveg_rfsim_requirer_interface.py
+++ b/tests/unit/lib/charms/oai_ran_du/v0/test_fiveg_rfsim_requirer_interface.py
@@ -1,0 +1,96 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from unittest.mock import patch
+
+import pytest
+import scenario
+
+from lib.charms.oai_ran_du_k8s.v0.fiveg_rfsim import FivegRFSIMInformationAvailableEvent
+from tests.unit.lib.charms.oai_ran_du.v0.test_charms.test_requirer_charm.src.charm import (
+    DummyFivegRFSIMRequires,
+)
+
+
+class TestFivegRFSIMRequires:
+    @pytest.fixture(autouse=True)
+    def setUp(self, request):
+        yield
+        request.addfinalizer(self.tearDown)
+
+    def tearDown(self) -> None:
+        patch.stopall()
+
+    @pytest.fixture(autouse=True)
+    def context(self):
+        self.ctx = scenario.Context(
+            charm_type=DummyFivegRFSIMRequires,
+            meta={
+                "name": "rfsim-requirer-charm",
+                "requires": {"fiveg_rfsim": {"interface": "fiveg_rfsim"}},
+            },
+            actions={
+                "get-rfsim-information": {"params": {}},
+            },
+        )
+
+    def test_given_fiveg_rfsim_relation_created_when_relation_changed_then_event_with_provider_rfsim_address_is_emitted(  # noqa: E501
+        self,
+    ):
+        fiveg_rfsim_relation = scenario.Relation(
+            endpoint="fiveg_rfsim",
+            interface="fiveg_rfsim",
+            remote_app_data={
+                "rfsim_address": "192.168.70.130:4043",
+            },
+        )
+        state_in = scenario.State(
+            relations=[fiveg_rfsim_relation],
+            leader=True,
+        )
+
+        self.ctx.run(fiveg_rfsim_relation.changed_event, state_in)
+
+        assert len(self.ctx.emitted_events) == 2
+        assert isinstance(self.ctx.emitted_events[1], FivegRFSIMInformationAvailableEvent)
+        assert self.ctx.emitted_events[1].rfsim_address == "192.168.70.130:4043"
+
+    def test_given_rfsim_information_not_in_relation_data_when_relation_changed_then_rfsim_information_available_event_is_not_emitted(  # noqa: E501
+        self,
+    ):
+        fiveg_rfsim_relation = scenario.Relation(
+            endpoint="fiveg_rfsim",
+            interface="fiveg_rfsim",
+        )
+        state_in = scenario.State(
+            leader=True,
+            relations=[fiveg_rfsim_relation],
+        )
+
+        self.ctx.run(fiveg_rfsim_relation.changed_event, state_in)
+
+        assert len(self.ctx.emitted_events) == 1
+
+    def test_given_rfsim_information_in_relation_data_when_get_rfsim_information_is_called_then_information_is_returned(  # noqa: E501
+        self,
+    ):
+        fiveg_rfsim_relation = scenario.Relation(
+            endpoint="fiveg_rfsim",
+            interface="fiveg_rfsim",
+            remote_app_data={
+                "rfsim_address": "192.168.70.130:4043",
+            },
+        )
+        state_in = scenario.State(
+            leader=True,
+            relations=[fiveg_rfsim_relation],
+        )
+        action = scenario.Action(
+            name="get-rfsim-information",
+        )
+
+        action_output = self.ctx.run_action(action, state_in)
+
+        assert action_output.success is True
+        assert action_output.results
+        assert action_output.results == {"rfsim-address": "192.168.70.130:4043"}

--- a/tests/unit/test_charm_fiveg_rfsim_relation_joined.py
+++ b/tests/unit/test_charm_fiveg_rfsim_relation_joined.py
@@ -1,0 +1,94 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+
+import tempfile
+
+import scenario
+from ops.pebble import Layer, ServiceStatus
+
+from tests.unit.fixtures import DUFixtures
+
+
+class TestCharmFivegRFSIMRelationJoined(DUFixtures):
+    def test_given_service_not_running_when_fiveg_rfsim_relation_joined_then_rfsim_information_is_not_in_relation_databag(  # noqa: E501
+        self,
+    ):
+        fiveg_rfsim_relation = scenario.Relation(endpoint="fiveg_rfsim", interface="fiveg_rfsim")
+        container = scenario.Container(name="du", can_connect=True)
+        state_in = scenario.State(
+            leader=True,
+            containers=[container],
+            relations=[fiveg_rfsim_relation],
+        )
+        self.mock_check_output.return_value = b"1.2.3.4"
+        self.mock_k8s_service_patch.get_ip.return_value = "1.2.3.4"
+
+        state_out = self.ctx.run(fiveg_rfsim_relation.joined_event, state_in)
+
+        assert state_out.relations[0].local_app_data == {}
+
+    def test_given_given_service_is_running_when_fiveg_rfsim_relation_joined_then_rfsim_information_is_in_relation_databag(  # noqa: E501
+        self,
+    ):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self.mock_du_security_context.is_privileged.return_value = True
+            self.mock_du_usb_volume.is_mounted.return_value = True
+            self.mock_f1_requires_f1_ip_address.return_value = "4.3.2.1"
+            self.mock_f1_requires_f1_port.return_value = 2153
+            self.mock_check_output.return_value = b"1.2.3.4"
+            f1_relation = scenario.Relation(
+                endpoint="fiveg_f1",
+                interface="fiveg_f1",
+            )
+            fiveg_rfsim_relation = scenario.Relation(
+                endpoint="fiveg_rfsim",
+                interface="fiveg_rfsim",
+                local_app_data={"rfsim_address": "1.2.3.4:4043"},
+            )
+            config_mount = scenario.Mount(
+                src=temp_dir,
+                location="/tmp/conf",
+            )
+            container = scenario.Container(
+                name="du",
+                can_connect=True,
+                layers={
+                    "du": Layer(
+                        {
+                            "services": {
+                                "du": {
+                                    "startup": "enabled",
+                                    "override": "replace",
+                                    "command": "/opt/oai-gnb/bin/nr-softmodem -O /tmp/conf/du.conf -E --sa ",  # noqa: E501
+                                    # noqa: E501
+                                    "environment": {"TZ": "UTC"},
+                                }
+                            }
+                        }
+                    )
+                },
+                service_status={"du": ServiceStatus.ACTIVE},
+                mounts={
+                    "config": config_mount,
+                },
+                exec_mock={
+                    ("ip", "route", "show"): scenario.ExecOutput(
+                        return_code=0,
+                        stdout="192.168.251.0/24 dev f1 scope link",
+                        stderr="",
+                    ),
+                },
+            )
+            state_in = scenario.State(
+                leader=True,
+                relations=[f1_relation, fiveg_rfsim_relation],
+                containers=[container],
+                model=scenario.Model(name="whatever"),
+                config={"simulation-mode": True},
+            )
+            self.mock_rfsim_set_information.return_value = "1.2.3.4:4043"
+
+            state_out = self.ctx.run(fiveg_rfsim_relation.joined_event, state_in)
+
+            assert state_out.relations[1].local_app_data == {"rfsim_address": "1.2.3.4:4043"}


### PR DESCRIPTION
# Description

Implement the provider side of `fiveg_rfsim` interface: https://github.com/canonical/charm-relation-interfaces/pull/175


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library