### PR TITLE
fix: Adds F1 route when using bridge CNI

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -59,7 +59,7 @@ config:
       description: DU F1 interface IP Address in CIDR format
     f1-port:
       type: int
-      default: 2153
+      default: 2152
       description: Number of the port handling communication over the F1 interface.
     mcc:
       type: string

--- a/tests/unit/resources/expected_config.conf
+++ b/tests/unit/resources/expected_config.conf
@@ -98,9 +98,9 @@ MACRLCs =
         local_n_address    = "192.168.251.5";
         remote_n_address   = "4.3.2.1";
         local_n_portc      = 500;
-        local_n_portd      = 2153;
+        local_n_portd      = 2152;
         remote_n_portc     = 501;
-        remote_n_portd     = 2153;
+        remote_n_portd     = 2152;
         pusch_TargetSNRx10 = 200;
         pucch_TargetSNRx10 = 200;
     }

--- a/tests/unit/resources/expected_rfsim_mode_config.conf
+++ b/tests/unit/resources/expected_rfsim_mode_config.conf
@@ -98,9 +98,9 @@ MACRLCs =
         local_n_address    = "192.168.251.5";
         remote_n_address   = "4.3.2.1";
         local_n_portc      = 500;
-        local_n_portd      = 2153;
+        local_n_portd      = 2152;
         remote_n_portc     = 501;
-        remote_n_portd     = 2153;
+        remote_n_portd     = 2152;
         pusch_TargetSNRx10 = 200;
         pucch_TargetSNRx10 = 200;
     }

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -78,7 +78,7 @@ class TestCharmConfigure(DUFixtures):
             self.mock_du_security_context.is_privileged.return_value = True
             self.mock_du_usb_volume.is_mounted.return_value = True
             self.mock_f1_requires_f1_ip_address.return_value = "4.3.2.1"
-            self.mock_f1_requires_f1_port.return_value = 2153
+            self.mock_f1_requires_f1_port.return_value = 2152
             self.mock_check_output.return_value = b"1.2.3.4"
             f1_relation = scenario.Relation(
                 endpoint="fiveg_f1",
@@ -93,6 +93,13 @@ class TestCharmConfigure(DUFixtures):
                 can_connect=True,
                 mounts={
                     "config": config_mount,
+                },
+                exec_mock={
+                    ("ip", "route", "show"): scenario.ExecOutput(
+                        return_code=0,
+                        stdout="192.168.251.0/24 dev f1 scope link",
+                        stderr="",
+                    ),
                 },
             )
             state_in = scenario.State(
@@ -119,7 +126,7 @@ class TestCharmConfigure(DUFixtures):
             self.mock_du_security_context.is_privileged.return_value = True
             self.mock_du_usb_volume.is_mounted.return_value = True
             self.mock_f1_requires_f1_ip_address.return_value = "4.3.2.1"
-            self.mock_f1_requires_f1_port.return_value = 2153
+            self.mock_f1_requires_f1_port.return_value = 2152
             self.mock_check_output.return_value = b"1.2.3.4"
             f1_relation = scenario.Relation(
                 endpoint="fiveg_f1",
@@ -134,6 +141,13 @@ class TestCharmConfigure(DUFixtures):
                 can_connect=True,
                 mounts={
                     "config": config_mount,
+                },
+                exec_mock={
+                    ("ip", "route", "show"): scenario.ExecOutput(
+                        return_code=0,
+                        stdout="192.168.251.0/24 dev f1 scope link",
+                        stderr="",
+                    ),
                 },
             )
             state_in = scenario.State(
@@ -163,7 +177,7 @@ class TestCharmConfigure(DUFixtures):
             self.mock_du_security_context.is_privileged.return_value = True
             self.mock_du_usb_volume.is_mounted.return_value = True
             self.mock_f1_requires_f1_ip_address.return_value = "4.3.2.1"
-            self.mock_f1_requires_f1_port.return_value = 2153
+            self.mock_f1_requires_f1_port.return_value = 2152
             self.mock_check_output.return_value = b"1.2.3.4"
             f1_relation = scenario.Relation(
                 endpoint="fiveg_f1",
@@ -178,6 +192,13 @@ class TestCharmConfigure(DUFixtures):
                 can_connect=True,
                 mounts={
                     "config": config_mount,
+                },
+                exec_mock={
+                    ("ip", "route", "show"): scenario.ExecOutput(
+                        return_code=0,
+                        stdout="192.168.251.0/24 dev f1 scope link",
+                        stderr="",
+                    ),
                 },
             )
             state_in = scenario.State(
@@ -203,7 +224,7 @@ class TestCharmConfigure(DUFixtures):
             self.mock_du_security_context.is_privileged.return_value = True
             self.mock_du_usb_volume.is_mounted.return_value = True
             self.mock_f1_requires_f1_ip_address.return_value = "4.3.2.1"
-            self.mock_f1_requires_f1_port.return_value = 2153
+            self.mock_f1_requires_f1_port.return_value = 2152
             self.mock_check_output.return_value = b"1.2.3.4"
             f1_relation = scenario.Relation(
                 endpoint="fiveg_f1",
@@ -218,6 +239,13 @@ class TestCharmConfigure(DUFixtures):
                 can_connect=True,
                 mounts={
                     "config": config_mount,
+                },
+                exec_mock={
+                    ("ip", "route", "show"): scenario.ExecOutput(
+                        return_code=0,
+                        stdout="192.168.251.0/24 dev f1 scope link",
+                        stderr="",
+                    ),
                 },
             )
             state_in = scenario.State(
@@ -251,7 +279,7 @@ class TestCharmConfigure(DUFixtures):
             self.mock_du_security_context.is_privileged.return_value = True
             self.mock_du_usb_volume.is_mounted.return_value = True
             self.mock_f1_requires_f1_ip_address.return_value = "4.3.2.1"
-            self.mock_f1_requires_f1_port.return_value = 2153
+            self.mock_f1_requires_f1_port.return_value = 2152
             self.mock_check_output.return_value = b"1.2.3.4"
             f1_relation = scenario.Relation(
                 endpoint="fiveg_f1",
@@ -266,6 +294,13 @@ class TestCharmConfigure(DUFixtures):
                 can_connect=True,
                 mounts={
                     "config": config_mount,
+                },
+                exec_mock={
+                    ("ip", "route", "show"): scenario.ExecOutput(
+                        return_code=0,
+                        stdout="192.168.251.0/24 dev f1 scope link",
+                        stderr="",
+                    ),
                 },
             )
             state_in = scenario.State(
@@ -300,7 +335,152 @@ class TestCharmConfigure(DUFixtures):
             self.mock_du_security_context.is_privileged.return_value = True
             self.mock_du_usb_volume.is_mounted.return_value = True
             self.mock_f1_requires_f1_ip_address.return_value = "4.3.2.1"
-            self.mock_f1_requires_f1_port.return_value = 2153
+            self.mock_f1_requires_f1_port.return_value = 2152
+            self.mock_check_output.return_value = b"1.2.3.4"
+            f1_relation = scenario.Relation(
+                endpoint="fiveg_f1",
+                interface="fiveg_f1",
+            )
+            config_mount = scenario.Mount(
+                src=temp_dir,
+                location="/tmp/conf",
+            )
+            container = scenario.Container(
+                name="du",
+                can_connect=True,
+                mounts={
+                    "config": config_mount,
+                },
+                exec_mock={
+                    ("ip", "route", "show"): scenario.ExecOutput(
+                        return_code=0,
+                        stdout="192.168.251.0/24 dev f1 scope link",
+                        stderr="",
+                    ),
+                },
+            )
+            state_in = scenario.State(
+                leader=True,
+                relations=[f1_relation],
+                containers=[container],
+                model=scenario.Model(name="whatever"),
+                config={"simulation-mode": True},
+            )
+
+            self.ctx.run(container.pebble_ready_event, state_in)
+
+            self.mock_f1_set_information.assert_called_once_with(port=2152)
+
+    def test_given_f1_route_not_created_when_config_changed_then_f1_route_is_created(self, caplog):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self.mock_du_security_context.is_privileged.return_value = True
+            self.mock_du_usb_volume.is_mounted.return_value = True
+            self.mock_f1_requires_f1_ip_address.return_value = "4.3.2.1"
+            self.mock_f1_requires_f1_port.return_value = 2152
+            self.mock_check_output.return_value = b"1.2.3.4"
+            f1_relation = scenario.Relation(
+                endpoint="fiveg_f1",
+                interface="fiveg_f1",
+            )
+            config_mount = scenario.Mount(
+                src=temp_dir,
+                location="/tmp/conf",
+            )
+            container = scenario.Container(
+                name="du",
+                can_connect=True,
+                mounts={
+                    "config": config_mount,
+                },
+                exec_mock={
+                    ("ip", "route", "show"): scenario.ExecOutput(
+                        return_code=0,
+                        stdout="",
+                        stderr="",
+                    ),
+                    (
+                        "ip",
+                        "route",
+                        "replace",
+                        "192.168.251.0/24",
+                        "dev",
+                        "f1",
+                    ): scenario.ExecOutput(
+                        return_code=0,
+                        stdout="",
+                        stderr="",
+                    ),
+                },
+            )
+            state_in = scenario.State(
+                leader=True,
+                relations=[f1_relation],
+                containers=[container],
+                model=scenario.Model(name="whatever"),
+                config={"simulation-mode": True},
+            )
+
+            self.ctx.run(container.pebble_ready_event, state_in)
+
+            # When scenario 7 is out, we should assert that the mock exec was called
+            # instead of validating log content
+            # Reference: https://github.com/canonical/ops-scenario/issues/180
+            assert "F1 route created" in caplog.text
+
+    def test_given_f1_route_created_when_config_changed_then_f1_route_is_not_created(self, caplog):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self.mock_du_security_context.is_privileged.return_value = True
+            self.mock_du_usb_volume.is_mounted.return_value = True
+            self.mock_f1_requires_f1_ip_address.return_value = "4.3.2.1"
+            self.mock_f1_requires_f1_port.return_value = 2152
+            self.mock_check_output.return_value = b"1.2.3.4"
+            f1_relation = scenario.Relation(
+                endpoint="fiveg_f1",
+                interface="fiveg_f1",
+            )
+            config_mount = scenario.Mount(
+                src=temp_dir,
+                location="/tmp/conf",
+            )
+            container = scenario.Container(
+                name="du",
+                can_connect=True,
+                mounts={
+                    "config": config_mount,
+                },
+                exec_mock={
+                    ("ip", "route", "show"): scenario.ExecOutput(
+                        return_code=0,
+                        stdout="192.168.251.0/24 dev f1 scope link",
+                        stderr="",
+                    ),
+                },
+            )
+            state_in = scenario.State(
+                leader=True,
+                relations=[f1_relation],
+                containers=[container],
+                model=scenario.Model(name="whatever"),
+                config={"simulation-mode": True},
+            )
+
+            self.ctx.run(container.pebble_ready_event, state_in)
+
+            # When scenario 7 is out, we should assert that the mock exec was called
+            # instead of validating log content
+            # Reference: https://github.com/canonical/ops-scenario/issues/180
+            assert "F1 route created" not in caplog.text
+
+    def test_given_cni_type_is_macvlan_when_config_changed_then_f1_route_is_not_created(self):
+        from unittest.mock import patch
+
+        patcher_exec = patch("ops.model.Container.exec")
+        mock_exec = patcher_exec.start()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self.mock_du_security_context.is_privileged.return_value = True
+            self.mock_du_usb_volume.is_mounted.return_value = True
+            self.mock_f1_requires_f1_ip_address.return_value = "4.3.2.1"
+            self.mock_f1_requires_f1_port.return_value = 2152
             self.mock_check_output.return_value = b"1.2.3.4"
             f1_relation = scenario.Relation(
                 endpoint="fiveg_f1",
@@ -322,9 +502,9 @@ class TestCharmConfigure(DUFixtures):
                 relations=[f1_relation],
                 containers=[container],
                 model=scenario.Model(name="whatever"),
-                config={"simulation-mode": True},
+                config={"cni-type": "macvlan"},
             )
 
             self.ctx.run(container.pebble_ready_event, state_in)
 
-            self.mock_f1_set_information.assert_called_once_with(port=2153)
+            mock_exec.assert_not_called()


### PR DESCRIPTION
# Description

When using `bridge` CNI for Multus, additional route is required to tell the workload which interface should be used for the F1 communication.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library