### PR TITLE
fix: remove port number from rfsim relation data

### DIFF
--- a/lib/charms/oai_ran_du_k8s/v0/fiveg_rfsim.py
+++ b/lib/charms/oai_ran_du_k8s/v0/fiveg_rfsim.py
@@ -35,7 +35,7 @@ from charms.oai_ran_du_k8s.v0.fiveg_rfsim import RFSIMProvides
 
 class DummyFivegRFSIMProviderCharm(CharmBase):
 
-    RFSIM_ADDRESS = "192.168.70.130:4043"
+    RFSIM_ADDRESS = "192.168.70.130"
 
     def __init__(self, *args):
         super().__init__(*args)
@@ -47,7 +47,7 @@ class DummyFivegRFSIMProviderCharm(CharmBase):
     def _on_fiveg_rfsim_relation_joined(self, event: RelationJoinedEvent):
         if self.unit.is_leader():
             self.rfsim_provider.set_rfsim_information(
-                rfsim_address=self.RFSIM_ADDRESS,
+                rfsim_address=self.RFSIM_ADDRESS
             )
 
 
@@ -109,7 +109,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 
 logger = logging.getLogger(__name__)
@@ -119,8 +119,8 @@ class FivegRFSIMProviderAppData(BaseModel):
     """Provider app data for fiveg_rfsim."""
 
     rfsim_address: str = Field(
-        description="RF simulator service address of DU including DU pod ip and port",
-        examples=["192.168.70.130:4043"],
+        description="RF simulator service address which is equal to DU pod ip",
+        examples=["192.168.70.130"],
     )
 
 
@@ -196,7 +196,7 @@ class RFSIMProvides(Object):
         """Push the information about the RFSIM interface in the application relation data.
 
         Args:
-            rfsim_address (str): rfsim service address including the pod ip and port number.
+            rfsim_address (str): rfsim service address which is equal to DU pod ip.
         """
         if not self.charm.unit.is_leader():
             raise FivegRFSIMError("Unit must be leader to set application relation data.")
@@ -241,7 +241,7 @@ class RFSIMRequires(Object):
         """Return address of the RFSIM.
 
         Returns:
-            str: rfsim address including pod ip and port number.
+            str: rfsim address which is equal to DU pod ip.
         """
         if remote_app_relation_data := self._get_remote_app_relation_data():
             return remote_app_relation_data.get("rfsim_address")

--- a/src/charm.py
+++ b/src/charm.py
@@ -46,7 +46,6 @@ F1_RELATION_NAME = "fiveg_f1"
 RFSIM_RELATION_NAME = "fiveg_rfsim"
 LOGGING_RELATION_NAME = "logging"
 WORKLOAD_VERSION_FILE_NAME = "/etc/workload-version"
-RFSIM_PORT = 4043
 
 
 class OAIRANDUOperator(CharmBase):
@@ -262,11 +261,11 @@ class OAIRANDUOperator(CharmBase):
         """Return the RFSIM service address.
 
         Returns:
-            str/None: Pod ip address together with RFSIM service port
+            str/None: DU Pod ip address
             if pod is running else None
         """
         if _get_pod_ip():
-            return f"{_get_pod_ip()}:{RFSIM_PORT}"
+            return str(_get_pod_ip())
         return ""
 
     def _du_service_is_running(self) -> bool:

--- a/tests/unit/lib/charms/oai_ran_du/v0/test_fiveg_rfsim_provider_interface.py
+++ b/tests/unit/lib/charms/oai_ran_du/v0/test_fiveg_rfsim_provider_interface.py
@@ -48,12 +48,12 @@ class TestFivegRFSIMProvides:
         action = scenario.Action(
             name="set-rfsim-information",
             params={
-                "rfsim_address": "1.2.3.4:4043",
+                "rfsim_address": "1.2.3.4",
             },
         )
         action_output = self.ctx.run_action(action, state_in)
 
-        assert action_output.state.relations[0].local_app_data["rfsim_address"] == "1.2.3.4:4043"
+        assert action_output.state.relations[0].local_app_data["rfsim_address"] == "1.2.3.4"
 
     def test_given_invalid_rfsim_address_when_set_rfsim_information_then_error_is_raised(self):
         fiveg_rfsim_relation = scenario.Relation(
@@ -92,7 +92,7 @@ class TestFivegRFSIMProvides:
         action = scenario.Action(
             name="set-rfsim-information",
             params={
-                "rfsim_address": "1.2.3.4:4043",
+                "rfsim_address": "1.2.3.4",
             },
         )
 

--- a/tests/unit/lib/charms/oai_ran_du/v0/test_fiveg_rfsim_requirer_interface.py
+++ b/tests/unit/lib/charms/oai_ran_du/v0/test_fiveg_rfsim_requirer_interface.py
@@ -41,7 +41,7 @@ class TestFivegRFSIMRequires:
             endpoint="fiveg_rfsim",
             interface="fiveg_rfsim",
             remote_app_data={
-                "rfsim_address": "192.168.70.130:4043",
+                "rfsim_address": "192.168.70.130",
             },
         )
         state_in = scenario.State(
@@ -53,7 +53,7 @@ class TestFivegRFSIMRequires:
 
         assert len(self.ctx.emitted_events) == 2
         assert isinstance(self.ctx.emitted_events[1], FivegRFSIMInformationAvailableEvent)
-        assert self.ctx.emitted_events[1].rfsim_address == "192.168.70.130:4043"
+        assert self.ctx.emitted_events[1].rfsim_address == "192.168.70.130"
 
     def test_given_rfsim_information_not_in_relation_data_when_relation_changed_then_rfsim_information_available_event_is_not_emitted(  # noqa: E501
         self,
@@ -78,7 +78,7 @@ class TestFivegRFSIMRequires:
             endpoint="fiveg_rfsim",
             interface="fiveg_rfsim",
             remote_app_data={
-                "rfsim_address": "192.168.70.130:4043",
+                "rfsim_address": "192.168.70.130",
             },
         )
         state_in = scenario.State(
@@ -93,4 +93,4 @@ class TestFivegRFSIMRequires:
 
         assert action_output.success is True
         assert action_output.results
-        assert action_output.results == {"rfsim-address": "192.168.70.130:4043"}
+        assert action_output.results == {"rfsim-address": "192.168.70.130"}

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -554,4 +554,4 @@ class TestCharmConfigure(DUFixtures):
 
             self.ctx.run(container.pebble_ready_event, state_in)
 
-            self.mock_rfsim_set_information.assert_called_once_with("1.2.3.4:4043")
+            self.mock_rfsim_set_information.assert_called_once_with("1.2.3.4")

--- a/tests/unit/test_charm_fiveg_rfsim_relation_joined.py
+++ b/tests/unit/test_charm_fiveg_rfsim_relation_joined.py
@@ -44,7 +44,7 @@ class TestCharmFivegRFSIMRelationJoined(DUFixtures):
             fiveg_rfsim_relation = scenario.Relation(
                 endpoint="fiveg_rfsim",
                 interface="fiveg_rfsim",
-                local_app_data={"rfsim_address": "1.2.3.4:4043"},
+                local_app_data={"rfsim_address": "1.2.3.4"},
             )
             config_mount = scenario.Mount(
                 src=temp_dir,
@@ -87,8 +87,8 @@ class TestCharmFivegRFSIMRelationJoined(DUFixtures):
                 model=scenario.Model(name="whatever"),
                 config={"simulation-mode": True},
             )
-            self.mock_rfsim_set_information.return_value = "1.2.3.4:4043"
+            self.mock_rfsim_set_information.return_value = "1.2.3.4"
 
             state_out = self.ctx.run(fiveg_rfsim_relation.joined_event, state_in)
 
-            assert state_out.relations[1].local_app_data == {"rfsim_address": "1.2.3.4:4043"}
+            assert state_out.relations[1].local_app_data == {"rfsim_address": "1.2.3.4"}


### PR DESCRIPTION
# Description

Port number should not be used to constitute  rfsim_address. Only pod ip is enough  as 4043 port number is added by workload.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library