### PR TITLE
feat: Expose fiveg_rfsim endpoint in terraform module

### DIFF
--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -13,6 +13,11 @@ output "fiveg_f1_endpoint" {
   value       = "fiveg_f1"
 }
 
+output "fiveg_rfsim_endpoint" {
+  description = "Name of the endpoint used to provide information about the rfsim interface."
+  value       = "fiveg_rfsim"
+}
+
 output "logging_endpoint" {
   description = "Name of the endpoint used to integrate with the Logging provider."
   value       = "logging"


### PR DESCRIPTION
# Description

Expose the `fiveg_rfsim` endpoint in the Terraform module.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library