### PR TITLE
fix: Use updated configuration suggested by upstream

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -425,7 +425,7 @@ class OAIRANDUOperator(CharmBase):
         rfsim_switch = ""
         if self._charm_config.simulation_mode:
             rfsim_switch = "--rfsim"
-        return f"/opt/oai-gnb/bin/nr-softmodem -O {BASE_CONFIG_PATH}/{CONFIG_FILE_NAME} -E --sa {rfsim_switch}"  # noqa: E501
+        return f"/opt/oai-gnb/bin/nr-softmodem -O {BASE_CONFIG_PATH}/{CONFIG_FILE_NAME} -E {rfsim_switch}"  # noqa: E501
 
     @property
     def _du_environment_variables(self) -> dict:

--- a/src/templates/du.conf.j2
+++ b/src/templates/du.conf.j2
@@ -1,9 +1,10 @@
 Active_gNBs = ( "{{ gnb_name }}" );
 Asn1_verbosity = "none";
+sa = 1;
 
 gNBs =
 (
-    {
+{
         gNB_ID    = 0xe00;
         gNB_DU_ID = 0xe00;
         gNB_name  =  "{{ gnb_name }}";
@@ -20,72 +21,140 @@ gNBs =
         );
         nr_cellid        = 12345678L;
         min_rxtxtime     = 6;
+        do_CSIRS                                                  = 0;
+        do_SRS                                                    = 0;
+
         force_256qam_off = 1;
 
-        servingCellConfigCommon =
-        (
-            {
-                physCellId = 0;
+    servingCellConfigCommon = (
+    {
+      physCellId                                                    = 0;
+      #frequencyInfoDL
+      # this is 3300.30 MHz + (19 PRBs + 10 SCs)@30kHz SCS (GSCN: 7715)
+      absoluteFrequencySSB                                             = 620736;
+      dl_frequencyBand                                                 = 78;
+      # this is 3300.30 MHz
+      dl_absoluteFrequencyPointA                                       = 620020;
+      #scs-SpecificCarrierList
+      dl_offstToCarrier                                              = 0;
+      # subcarrierSpacing
+      # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      dl_subcarrierSpacing                                           = 1;
+      dl_carrierBandwidth                                            = 51;
+      #initialDownlinkBWP
+      #genericParameters
+      # this is RBstart=27,L=48 (275*(L-1))+RBstart
+      initialDLBWPlocationAndBandwidth                               = 13750;
+      # subcarrierSpacing
+      # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      initialDLBWPsubcarrierSpacing                                   = 1;
+      #pdcch-ConfigCommon
+      initialDLBWPcontrolResourceSetZero                              = 12;
+      initialDLBWPsearchSpaceZero                                     = 0;
 
-                absoluteFrequencySSB                         = 641280;
-                dl_frequencyBand                             = 78;
-                dl_absoluteFrequencyPointA                   = 640008;
-                dl_offstToCarrier                            = 0;
-                dl_subcarrierSpacing                         = 1;
-                dl_carrierBandwidth                          = 106;
-                initialDLBWPlocationAndBandwidth             = 28875;
-                initialDLBWPsubcarrierSpacing                = 1;
-                initialDLBWPcontrolResourceSetZero           = 12;
-                initialDLBWPsearchSpaceZero                  = 0;
-                ul_frequencyBand                             = 78;
-                ul_offstToCarrier                            = 0;
-                ul_subcarrierSpacing                         = 1;
-                ul_carrierBandwidth                          = 106;
-                pMax                                         = 20;
-                initialULBWPlocationAndBandwidth             = 28875;
-                initialULBWPsubcarrierSpacing                = 1;
-                prach_ConfigurationIndex                     = 98;
-                prach_msg1_FDM                               = 0;
-                prach_msg1_FrequencyStart                    = 0;
-                zeroCorrelationZoneConfig                    = 13;
-                preambleReceivedTargetPower                  = -96;
-                preambleTransMax                             = 6;
-                powerRampingStep                             = 1;
-                ra_ResponseWindow                            = 4;
-                ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR = 4;
-                ssb_perRACH_OccasionAndCB_PreamblesPerSSB    = 14;
-                ra_ContentionResolutionTimer                 = 7;
-                rsrp_ThresholdSSB                            = 19;
-                prach_RootSequenceIndex_PR                   = 2;
-                prach_RootSequenceIndex                      = 1;
-                msg1_SubcarrierSpacing                       = 1,
-                restrictedSetConfig                          = 0,
-                msg3_DeltaPreamble                           = 1;
-                p0_NominalWithGrant                          = -90;
-                pucchGroupHopping                            = 0;
-                hoppingId                                    = 40;
-                p0_nominal                                   = -90;
-                ssb_PositionsInBurst_PR                      = 2;
-                ssb_PositionsInBurst_Bitmap                  = 1;
-                ssb_periodicityServingCell                   = 2;
-                dmrs_TypeA_Position                          = 0;
-                subcarrierSpacing                            = 1;
-                referenceSubcarrierSpacing                   = 1;
-                dl_UL_TransmissionPeriodicity                = 6;
-                nrofDownlinkSlots                            = 7;
-                nrofDownlinkSymbols                          = 6;
-                nrofUplinkSlots                              = 2;
-                nrofUplinkSymbols                            = 4;
-                ssPBCH_BlockPower                            = -25;
-            }
-        );
+      #uplinkConfigCommon
+      #frequencyInfoUL
+      ul_frequencyBand                                              = 78;
+      #scs-SpecificCarrierList
+      ul_offstToCarrier                                             = 0;
+      # subcarrierSpacing
+      # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      ul_subcarrierSpacing                                          = 1;
+      ul_carrierBandwidth                                           = 51;
+      pMax                                                          = 20;
+      #initialUplinkBWP
+      #genericParameters
+      initialULBWPlocationAndBandwidth                            = 13750;
+      # subcarrierSpacing
+      # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      initialULBWPsubcarrierSpacing                               = 1;
+      #rach-ConfigCommon
+      #rach-ConfigGeneric
+      prach_ConfigurationIndex                                  = 98;
+      #prach_msg1_FDM
+      #0 = one, 1=two, 2=four, 3=eight
+      prach_msg1_FDM                                            = 0;
+      prach_msg1_FrequencyStart                                 = 0;
+      zeroCorrelationZoneConfig                                 = 13;
+      preambleReceivedTargetPower                               = -96;
+      #preamblTransMax (0...10) = (3,4,5,6,7,8,10,20,50,100,200)
+      preambleTransMax                                          = 6;
+      #powerRampingStep
+      # 0=dB0,1=dB2,2=dB4,3=dB6
+      powerRampingStep                                            = 1;
+      #ra_ReponseWindow
+      #1,2,4,8,10,20,40,80
+      ra_ResponseWindow                                           = 4;
+      #ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR
+      #1=oneeighth,2=onefourth,3=half,4=one,5=two,6=four,7=eight,8=sixteen
+      ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR                = 4;
+      #oneHalf (0..15) 4,8,12,16,...60,64
+      ssb_perRACH_OccasionAndCB_PreamblesPerSSB                   = 14;
+      #ra_ContentionResolutionTimer
+      #(0..7) 8,16,24,32,40,48,56,64
+      ra_ContentionResolutionTimer                                = 7;
+      rsrp_ThresholdSSB                                           = 19;
+      #prach-RootSequenceIndex_PR
+      #1 = 839, 2 = 139
+      prach_RootSequenceIndex_PR                                  = 2;
+      prach_RootSequenceIndex                                     = 1;
+      # SCS for msg1, can only be 15 for 30 kHz < 6 GHz, takes precedence over the one derived from prach-ConfigIndex
+      #
+      msg1_SubcarrierSpacing                                      = 1,
+      # restrictedSetConfig
+      # 0=unrestricted, 1=restricted type A, 2=restricted type B
+      restrictedSetConfig                                         = 0,
 
-        SCTP:
-        {
-            SCTP_INSTREAMS  = 2;
-            SCTP_OUTSTREAMS = 2;
-        };
-    }
+      msg3_DeltaPreamble                                          = 1;
+      p0_NominalWithGrant                                         =-90;
+
+      # pucch-ConfigCommon setup :
+      # pucchGroupHopping
+      # 0 = neither, 1= group hopping, 2=sequence hopping
+      pucchGroupHopping                                           = 0;
+      hoppingId                                                   = 40;
+      p0_nominal                                                  = -90;
+      # ssb_PositionsInBurs_BitmapPR
+      # 1=short, 2=medium, 3=long
+      ssb_PositionsInBurst_PR                                       = 2;
+      ssb_PositionsInBurst_Bitmap                                   = 1;
+
+      # ssb_periodicityServingCell
+      # 0 = ms5, 1=ms10, 2=ms20, 3=ms40, 4=ms80, 5=ms160, 6=spare2, 7=spare1
+      ssb_periodicityServingCell                                    = 2;
+
+      # dmrs_TypeA_position
+      # 0 = pos2, 1 = pos3
+      dmrs_TypeA_Position                                           = 0;
+
+      # subcarrierSpacing
+      # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      subcarrierSpacing                                             = 1;
+
+
+      #tdd-UL-DL-ConfigurationCommon
+      # subcarrierSpacing
+      # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      referenceSubcarrierSpacing                                    = 1;
+      # pattern1
+      # dl_UL_TransmissionPeriodicity
+      # 0=ms0p5, 1=ms0p625, 2=ms1, 3=ms1p25, 4=ms2, 5=ms2p5, 6=ms5, 7=ms10
+      dl_UL_TransmissionPeriodicity                                 = 6;
+      nrofDownlinkSlots                                             = 7;
+      nrofDownlinkSymbols                                           = 6;
+      nrofUplinkSlots                                               = 2;
+      nrofUplinkSymbols                                             = 4;
+
+      ssPBCH_BlockPower                                             = -25;
+  }
+  );
+
+  SCTP:
+    {
+      SCTP_INSTREAMS  = 2;
+      SCTP_OUTSTREAMS = 2;
+    };
+}
 );
 
 MACRLCs =
@@ -103,6 +172,9 @@ MACRLCs =
         remote_n_portd     = {{ cu_f1_port }};
         pusch_TargetSNRx10 = 200;
         pucch_TargetSNRx10 = 200;
+        ul_prbblack_SNR_threshold   = 10;
+        ulsch_max_frame_inactivity  = 0;
+
     }
 );
 
@@ -111,7 +183,7 @@ L1s =
     {
         num_cc               = 1;
         tr_n_preference      = "local_mac";
-        prach_dtx_threshold  = 200;
+        prach_dtx_threshold  = 120;
         pucch0_dtx_threshold = 150;
         ofdm_offset_divisor  = 8;
     }

--- a/tests/unit/resources/expected_config.conf
+++ b/tests/unit/resources/expected_config.conf
@@ -1,9 +1,10 @@
 Active_gNBs = ( "whatever-oai-ran-du-k8s-du" );
 Asn1_verbosity = "none";
+sa = 1;
 
 gNBs =
 (
-    {
+{
         gNB_ID    = 0xe00;
         gNB_DU_ID = 0xe00;
         gNB_name  =  "whatever-oai-ran-du-k8s-du";
@@ -20,72 +21,140 @@ gNBs =
         );
         nr_cellid        = 12345678L;
         min_rxtxtime     = 6;
+        do_CSIRS                                                  = 0;
+        do_SRS                                                    = 0;
+
         force_256qam_off = 1;
 
-        servingCellConfigCommon =
-        (
-            {
-                physCellId = 0;
+    servingCellConfigCommon = (
+    {
+      physCellId                                                    = 0;
+      #frequencyInfoDL
+      # this is 3300.30 MHz + (19 PRBs + 10 SCs)@30kHz SCS (GSCN: 7715)
+      absoluteFrequencySSB                                             = 620736;
+      dl_frequencyBand                                                 = 78;
+      # this is 3300.30 MHz
+      dl_absoluteFrequencyPointA                                       = 620020;
+      #scs-SpecificCarrierList
+      dl_offstToCarrier                                              = 0;
+      # subcarrierSpacing
+      # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      dl_subcarrierSpacing                                           = 1;
+      dl_carrierBandwidth                                            = 51;
+      #initialDownlinkBWP
+      #genericParameters
+      # this is RBstart=27,L=48 (275*(L-1))+RBstart
+      initialDLBWPlocationAndBandwidth                               = 13750;
+      # subcarrierSpacing
+      # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      initialDLBWPsubcarrierSpacing                                   = 1;
+      #pdcch-ConfigCommon
+      initialDLBWPcontrolResourceSetZero                              = 12;
+      initialDLBWPsearchSpaceZero                                     = 0;
 
-                absoluteFrequencySSB                         = 641280;
-                dl_frequencyBand                             = 78;
-                dl_absoluteFrequencyPointA                   = 640008;
-                dl_offstToCarrier                            = 0;
-                dl_subcarrierSpacing                         = 1;
-                dl_carrierBandwidth                          = 106;
-                initialDLBWPlocationAndBandwidth             = 28875;
-                initialDLBWPsubcarrierSpacing                = 1;
-                initialDLBWPcontrolResourceSetZero           = 12;
-                initialDLBWPsearchSpaceZero                  = 0;
-                ul_frequencyBand                             = 78;
-                ul_offstToCarrier                            = 0;
-                ul_subcarrierSpacing                         = 1;
-                ul_carrierBandwidth                          = 106;
-                pMax                                         = 20;
-                initialULBWPlocationAndBandwidth             = 28875;
-                initialULBWPsubcarrierSpacing                = 1;
-                prach_ConfigurationIndex                     = 98;
-                prach_msg1_FDM                               = 0;
-                prach_msg1_FrequencyStart                    = 0;
-                zeroCorrelationZoneConfig                    = 13;
-                preambleReceivedTargetPower                  = -96;
-                preambleTransMax                             = 6;
-                powerRampingStep                             = 1;
-                ra_ResponseWindow                            = 4;
-                ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR = 4;
-                ssb_perRACH_OccasionAndCB_PreamblesPerSSB    = 14;
-                ra_ContentionResolutionTimer                 = 7;
-                rsrp_ThresholdSSB                            = 19;
-                prach_RootSequenceIndex_PR                   = 2;
-                prach_RootSequenceIndex                      = 1;
-                msg1_SubcarrierSpacing                       = 1,
-                restrictedSetConfig                          = 0,
-                msg3_DeltaPreamble                           = 1;
-                p0_NominalWithGrant                          = -90;
-                pucchGroupHopping                            = 0;
-                hoppingId                                    = 40;
-                p0_nominal                                   = -90;
-                ssb_PositionsInBurst_PR                      = 2;
-                ssb_PositionsInBurst_Bitmap                  = 1;
-                ssb_periodicityServingCell                   = 2;
-                dmrs_TypeA_Position                          = 0;
-                subcarrierSpacing                            = 1;
-                referenceSubcarrierSpacing                   = 1;
-                dl_UL_TransmissionPeriodicity                = 6;
-                nrofDownlinkSlots                            = 7;
-                nrofDownlinkSymbols                          = 6;
-                nrofUplinkSlots                              = 2;
-                nrofUplinkSymbols                            = 4;
-                ssPBCH_BlockPower                            = -25;
-            }
-        );
+      #uplinkConfigCommon
+      #frequencyInfoUL
+      ul_frequencyBand                                              = 78;
+      #scs-SpecificCarrierList
+      ul_offstToCarrier                                             = 0;
+      # subcarrierSpacing
+      # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      ul_subcarrierSpacing                                          = 1;
+      ul_carrierBandwidth                                           = 51;
+      pMax                                                          = 20;
+      #initialUplinkBWP
+      #genericParameters
+      initialULBWPlocationAndBandwidth                            = 13750;
+      # subcarrierSpacing
+      # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      initialULBWPsubcarrierSpacing                               = 1;
+      #rach-ConfigCommon
+      #rach-ConfigGeneric
+      prach_ConfigurationIndex                                  = 98;
+      #prach_msg1_FDM
+      #0 = one, 1=two, 2=four, 3=eight
+      prach_msg1_FDM                                            = 0;
+      prach_msg1_FrequencyStart                                 = 0;
+      zeroCorrelationZoneConfig                                 = 13;
+      preambleReceivedTargetPower                               = -96;
+      #preamblTransMax (0...10) = (3,4,5,6,7,8,10,20,50,100,200)
+      preambleTransMax                                          = 6;
+      #powerRampingStep
+      # 0=dB0,1=dB2,2=dB4,3=dB6
+      powerRampingStep                                            = 1;
+      #ra_ReponseWindow
+      #1,2,4,8,10,20,40,80
+      ra_ResponseWindow                                           = 4;
+      #ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR
+      #1=oneeighth,2=onefourth,3=half,4=one,5=two,6=four,7=eight,8=sixteen
+      ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR                = 4;
+      #oneHalf (0..15) 4,8,12,16,...60,64
+      ssb_perRACH_OccasionAndCB_PreamblesPerSSB                   = 14;
+      #ra_ContentionResolutionTimer
+      #(0..7) 8,16,24,32,40,48,56,64
+      ra_ContentionResolutionTimer                                = 7;
+      rsrp_ThresholdSSB                                           = 19;
+      #prach-RootSequenceIndex_PR
+      #1 = 839, 2 = 139
+      prach_RootSequenceIndex_PR                                  = 2;
+      prach_RootSequenceIndex                                     = 1;
+      # SCS for msg1, can only be 15 for 30 kHz < 6 GHz, takes precedence over the one derived from prach-ConfigIndex
+      #
+      msg1_SubcarrierSpacing                                      = 1,
+      # restrictedSetConfig
+      # 0=unrestricted, 1=restricted type A, 2=restricted type B
+      restrictedSetConfig                                         = 0,
 
-        SCTP:
-        {
-            SCTP_INSTREAMS  = 2;
-            SCTP_OUTSTREAMS = 2;
-        };
-    }
+      msg3_DeltaPreamble                                          = 1;
+      p0_NominalWithGrant                                         =-90;
+
+      # pucch-ConfigCommon setup :
+      # pucchGroupHopping
+      # 0 = neither, 1= group hopping, 2=sequence hopping
+      pucchGroupHopping                                           = 0;
+      hoppingId                                                   = 40;
+      p0_nominal                                                  = -90;
+      # ssb_PositionsInBurs_BitmapPR
+      # 1=short, 2=medium, 3=long
+      ssb_PositionsInBurst_PR                                       = 2;
+      ssb_PositionsInBurst_Bitmap                                   = 1;
+
+      # ssb_periodicityServingCell
+      # 0 = ms5, 1=ms10, 2=ms20, 3=ms40, 4=ms80, 5=ms160, 6=spare2, 7=spare1
+      ssb_periodicityServingCell                                    = 2;
+
+      # dmrs_TypeA_position
+      # 0 = pos2, 1 = pos3
+      dmrs_TypeA_Position                                           = 0;
+
+      # subcarrierSpacing
+      # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      subcarrierSpacing                                             = 1;
+
+
+      #tdd-UL-DL-ConfigurationCommon
+      # subcarrierSpacing
+      # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      referenceSubcarrierSpacing                                    = 1;
+      # pattern1
+      # dl_UL_TransmissionPeriodicity
+      # 0=ms0p5, 1=ms0p625, 2=ms1, 3=ms1p25, 4=ms2, 5=ms2p5, 6=ms5, 7=ms10
+      dl_UL_TransmissionPeriodicity                                 = 6;
+      nrofDownlinkSlots                                             = 7;
+      nrofDownlinkSymbols                                           = 6;
+      nrofUplinkSlots                                               = 2;
+      nrofUplinkSymbols                                             = 4;
+
+      ssPBCH_BlockPower                                             = -25;
+  }
+  );
+
+  SCTP:
+    {
+      SCTP_INSTREAMS  = 2;
+      SCTP_OUTSTREAMS = 2;
+    };
+}
 );
 
 MACRLCs =
@@ -103,6 +172,9 @@ MACRLCs =
         remote_n_portd     = 2152;
         pusch_TargetSNRx10 = 200;
         pucch_TargetSNRx10 = 200;
+        ul_prbblack_SNR_threshold   = 10;
+        ulsch_max_frame_inactivity  = 0;
+
     }
 );
 
@@ -111,7 +183,7 @@ L1s =
     {
         num_cc               = 1;
         tr_n_preference      = "local_mac";
-        prach_dtx_threshold  = 200;
+        prach_dtx_threshold  = 120;
         pucch0_dtx_threshold = 150;
         ofdm_offset_divisor  = 8;
     }

--- a/tests/unit/resources/expected_rfsim_mode_config.conf
+++ b/tests/unit/resources/expected_rfsim_mode_config.conf
@@ -1,9 +1,10 @@
 Active_gNBs = ( "whatever-oai-ran-du-k8s-du" );
 Asn1_verbosity = "none";
+sa = 1;
 
 gNBs =
 (
-    {
+{
         gNB_ID    = 0xe00;
         gNB_DU_ID = 0xe00;
         gNB_name  =  "whatever-oai-ran-du-k8s-du";
@@ -20,72 +21,140 @@ gNBs =
         );
         nr_cellid        = 12345678L;
         min_rxtxtime     = 6;
+        do_CSIRS                                                  = 0;
+        do_SRS                                                    = 0;
+
         force_256qam_off = 1;
 
-        servingCellConfigCommon =
-        (
-            {
-                physCellId = 0;
+    servingCellConfigCommon = (
+    {
+      physCellId                                                    = 0;
+      #frequencyInfoDL
+      # this is 3300.30 MHz + (19 PRBs + 10 SCs)@30kHz SCS (GSCN: 7715)
+      absoluteFrequencySSB                                             = 620736;
+      dl_frequencyBand                                                 = 78;
+      # this is 3300.30 MHz
+      dl_absoluteFrequencyPointA                                       = 620020;
+      #scs-SpecificCarrierList
+      dl_offstToCarrier                                              = 0;
+      # subcarrierSpacing
+      # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      dl_subcarrierSpacing                                           = 1;
+      dl_carrierBandwidth                                            = 51;
+      #initialDownlinkBWP
+      #genericParameters
+      # this is RBstart=27,L=48 (275*(L-1))+RBstart
+      initialDLBWPlocationAndBandwidth                               = 13750;
+      # subcarrierSpacing
+      # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      initialDLBWPsubcarrierSpacing                                   = 1;
+      #pdcch-ConfigCommon
+      initialDLBWPcontrolResourceSetZero                              = 12;
+      initialDLBWPsearchSpaceZero                                     = 0;
 
-                absoluteFrequencySSB                         = 641280;
-                dl_frequencyBand                             = 78;
-                dl_absoluteFrequencyPointA                   = 640008;
-                dl_offstToCarrier                            = 0;
-                dl_subcarrierSpacing                         = 1;
-                dl_carrierBandwidth                          = 106;
-                initialDLBWPlocationAndBandwidth             = 28875;
-                initialDLBWPsubcarrierSpacing                = 1;
-                initialDLBWPcontrolResourceSetZero           = 12;
-                initialDLBWPsearchSpaceZero                  = 0;
-                ul_frequencyBand                             = 78;
-                ul_offstToCarrier                            = 0;
-                ul_subcarrierSpacing                         = 1;
-                ul_carrierBandwidth                          = 106;
-                pMax                                         = 20;
-                initialULBWPlocationAndBandwidth             = 28875;
-                initialULBWPsubcarrierSpacing                = 1;
-                prach_ConfigurationIndex                     = 98;
-                prach_msg1_FDM                               = 0;
-                prach_msg1_FrequencyStart                    = 0;
-                zeroCorrelationZoneConfig                    = 13;
-                preambleReceivedTargetPower                  = -96;
-                preambleTransMax                             = 6;
-                powerRampingStep                             = 1;
-                ra_ResponseWindow                            = 4;
-                ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR = 4;
-                ssb_perRACH_OccasionAndCB_PreamblesPerSSB    = 14;
-                ra_ContentionResolutionTimer                 = 7;
-                rsrp_ThresholdSSB                            = 19;
-                prach_RootSequenceIndex_PR                   = 2;
-                prach_RootSequenceIndex                      = 1;
-                msg1_SubcarrierSpacing                       = 1,
-                restrictedSetConfig                          = 0,
-                msg3_DeltaPreamble                           = 1;
-                p0_NominalWithGrant                          = -90;
-                pucchGroupHopping                            = 0;
-                hoppingId                                    = 40;
-                p0_nominal                                   = -90;
-                ssb_PositionsInBurst_PR                      = 2;
-                ssb_PositionsInBurst_Bitmap                  = 1;
-                ssb_periodicityServingCell                   = 2;
-                dmrs_TypeA_Position                          = 0;
-                subcarrierSpacing                            = 1;
-                referenceSubcarrierSpacing                   = 1;
-                dl_UL_TransmissionPeriodicity                = 6;
-                nrofDownlinkSlots                            = 7;
-                nrofDownlinkSymbols                          = 6;
-                nrofUplinkSlots                              = 2;
-                nrofUplinkSymbols                            = 4;
-                ssPBCH_BlockPower                            = -25;
-            }
-        );
+      #uplinkConfigCommon
+      #frequencyInfoUL
+      ul_frequencyBand                                              = 78;
+      #scs-SpecificCarrierList
+      ul_offstToCarrier                                             = 0;
+      # subcarrierSpacing
+      # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      ul_subcarrierSpacing                                          = 1;
+      ul_carrierBandwidth                                           = 51;
+      pMax                                                          = 20;
+      #initialUplinkBWP
+      #genericParameters
+      initialULBWPlocationAndBandwidth                            = 13750;
+      # subcarrierSpacing
+      # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      initialULBWPsubcarrierSpacing                               = 1;
+      #rach-ConfigCommon
+      #rach-ConfigGeneric
+      prach_ConfigurationIndex                                  = 98;
+      #prach_msg1_FDM
+      #0 = one, 1=two, 2=four, 3=eight
+      prach_msg1_FDM                                            = 0;
+      prach_msg1_FrequencyStart                                 = 0;
+      zeroCorrelationZoneConfig                                 = 13;
+      preambleReceivedTargetPower                               = -96;
+      #preamblTransMax (0...10) = (3,4,5,6,7,8,10,20,50,100,200)
+      preambleTransMax                                          = 6;
+      #powerRampingStep
+      # 0=dB0,1=dB2,2=dB4,3=dB6
+      powerRampingStep                                            = 1;
+      #ra_ReponseWindow
+      #1,2,4,8,10,20,40,80
+      ra_ResponseWindow                                           = 4;
+      #ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR
+      #1=oneeighth,2=onefourth,3=half,4=one,5=two,6=four,7=eight,8=sixteen
+      ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR                = 4;
+      #oneHalf (0..15) 4,8,12,16,...60,64
+      ssb_perRACH_OccasionAndCB_PreamblesPerSSB                   = 14;
+      #ra_ContentionResolutionTimer
+      #(0..7) 8,16,24,32,40,48,56,64
+      ra_ContentionResolutionTimer                                = 7;
+      rsrp_ThresholdSSB                                           = 19;
+      #prach-RootSequenceIndex_PR
+      #1 = 839, 2 = 139
+      prach_RootSequenceIndex_PR                                  = 2;
+      prach_RootSequenceIndex                                     = 1;
+      # SCS for msg1, can only be 15 for 30 kHz < 6 GHz, takes precedence over the one derived from prach-ConfigIndex
+      #
+      msg1_SubcarrierSpacing                                      = 1,
+      # restrictedSetConfig
+      # 0=unrestricted, 1=restricted type A, 2=restricted type B
+      restrictedSetConfig                                         = 0,
 
-        SCTP:
-        {
-            SCTP_INSTREAMS  = 2;
-            SCTP_OUTSTREAMS = 2;
-        };
-    }
+      msg3_DeltaPreamble                                          = 1;
+      p0_NominalWithGrant                                         =-90;
+
+      # pucch-ConfigCommon setup :
+      # pucchGroupHopping
+      # 0 = neither, 1= group hopping, 2=sequence hopping
+      pucchGroupHopping                                           = 0;
+      hoppingId                                                   = 40;
+      p0_nominal                                                  = -90;
+      # ssb_PositionsInBurs_BitmapPR
+      # 1=short, 2=medium, 3=long
+      ssb_PositionsInBurst_PR                                       = 2;
+      ssb_PositionsInBurst_Bitmap                                   = 1;
+
+      # ssb_periodicityServingCell
+      # 0 = ms5, 1=ms10, 2=ms20, 3=ms40, 4=ms80, 5=ms160, 6=spare2, 7=spare1
+      ssb_periodicityServingCell                                    = 2;
+
+      # dmrs_TypeA_position
+      # 0 = pos2, 1 = pos3
+      dmrs_TypeA_Position                                           = 0;
+
+      # subcarrierSpacing
+      # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      subcarrierSpacing                                             = 1;
+
+
+      #tdd-UL-DL-ConfigurationCommon
+      # subcarrierSpacing
+      # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
+      referenceSubcarrierSpacing                                    = 1;
+      # pattern1
+      # dl_UL_TransmissionPeriodicity
+      # 0=ms0p5, 1=ms0p625, 2=ms1, 3=ms1p25, 4=ms2, 5=ms2p5, 6=ms5, 7=ms10
+      dl_UL_TransmissionPeriodicity                                 = 6;
+      nrofDownlinkSlots                                             = 7;
+      nrofDownlinkSymbols                                           = 6;
+      nrofUplinkSlots                                               = 2;
+      nrofUplinkSymbols                                             = 4;
+
+      ssPBCH_BlockPower                                             = -25;
+  }
+  );
+
+  SCTP:
+    {
+      SCTP_INSTREAMS  = 2;
+      SCTP_OUTSTREAMS = 2;
+    };
+}
 );
 
 MACRLCs =
@@ -103,6 +172,9 @@ MACRLCs =
         remote_n_portd     = 2152;
         pusch_TargetSNRx10 = 200;
         pucch_TargetSNRx10 = 200;
+        ul_prbblack_SNR_threshold   = 10;
+        ulsch_max_frame_inactivity  = 0;
+
     }
 );
 
@@ -111,7 +183,7 @@ L1s =
     {
         num_cc               = 1;
         tr_n_preference      = "local_mac";
-        prach_dtx_threshold  = 200;
+        prach_dtx_threshold  = 120;
         pucch0_dtx_threshold = 150;
         ofdm_offset_divisor  = 8;
     }

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -187,7 +187,7 @@ class TestCharmConfigure(DUFixtures):
                 model=scenario.Model(name="whatever"),
             )
             with open("tests/unit/resources/expected_config.conf") as expected_config_file:
-                expected_config = expected_config_file.read()
+                expected_config = expected_config_file.read().strip()
             with open(f"{temp_dir}/du.conf", "w") as generated_config_file:
                 generated_config_file.write(expected_config)
             config_modification_time = os.stat(temp_dir + "/du.conf").st_mtime
@@ -236,7 +236,7 @@ class TestCharmConfigure(DUFixtures):
                             "du": {
                                 "startup": "enabled",
                                 "override": "replace",
-                                "command": "/opt/oai-gnb/bin/nr-softmodem -O /tmp/conf/du.conf -E --sa ",  # noqa: E501
+                                "command": "/opt/oai-gnb/bin/nr-softmodem -O /tmp/conf/du.conf -E ",  # noqa: E501
                                 "environment": {"TZ": "UTC"},
                             }
                         }
@@ -285,7 +285,7 @@ class TestCharmConfigure(DUFixtures):
                             "du": {
                                 "startup": "enabled",
                                 "override": "replace",
-                                "command": "/opt/oai-gnb/bin/nr-softmodem -O /tmp/conf/du.conf -E --sa --rfsim",  # noqa: E501
+                                "command": "/opt/oai-gnb/bin/nr-softmodem -O /tmp/conf/du.conf -E --rfsim",  # noqa: E501
                                 "environment": {"TZ": "UTC"},
                             }
                         }


### PR DESCRIPTION
# Description

Updates the configuration to one suggested by upstream that gave better results.

I kept the comments in the file as they are the best documentation we have for now.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library