### PR TITLE
chore: use built-in testing from ops

### DIFF
--- a/tests/unit/fixtures.py
+++ b/tests/unit/fixtures.py
@@ -5,7 +5,7 @@
 from unittest.mock import PropertyMock, patch
 
 import pytest
-import scenario
+from ops import testing
 
 from charm import OAIRANDUOperator
 
@@ -46,6 +46,6 @@ class DUFixtures:
 
     @pytest.fixture(autouse=True)
     def context(self):
-        self.ctx = scenario.Context(
+        self.ctx = testing.Context(
             charm_type=OAIRANDUOperator,
         )

--- a/tests/unit/lib/charms/oai_ran_du/v0/test_fiveg_rfsim_provider_interface.py
+++ b/tests/unit/lib/charms/oai_ran_du/v0/test_fiveg_rfsim_provider_interface.py
@@ -4,7 +4,7 @@
 from unittest.mock import patch
 
 import pytest
-import scenario
+from ops import testing
 
 from tests.unit.lib.charms.oai_ran_du.v0.test_charms.test_provider_charm.src.charm import (
     DummyFivegRFSIMProviderCharm,
@@ -22,7 +22,7 @@ class TestFivegRFSIMProvides:
 
     @pytest.fixture(autouse=True)
     def context(self):
-        self.ctx = scenario.Context(
+        self.ctx = testing.Context(
             charm_type=DummyFivegRFSIMProviderCharm,
             meta={
                 "name": "rfsim-provider-charm",
@@ -36,11 +36,11 @@ class TestFivegRFSIMProvides:
     def test_given_valid_rfsim_interface_data_when_set_rfsim_information_then_rfsim_address_is_pushed_to_the_relation_databag(  # noqa: E501
         self,
     ):
-        fiveg_rfsim_relation = scenario.Relation(
+        fiveg_rfsim_relation = testing.Relation(
             endpoint="fiveg_rfsim",
             interface="fiveg_rfsim",
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             relations=[fiveg_rfsim_relation],
             leader=True,
         )
@@ -56,11 +56,11 @@ class TestFivegRFSIMProvides:
         assert relation.local_app_data == {"rfsim_address": "1.2.3.4"}
 
     def test_given_invalid_rfsim_address_when_set_rfsim_information_then_error_is_raised(self):
-        fiveg_rfsim_relation = scenario.Relation(
+        fiveg_rfsim_relation = testing.Relation(
             endpoint="fiveg_rfsim",
             interface="fiveg_rfsim",
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             relations=[fiveg_rfsim_relation],
             leader=True,
         )
@@ -71,16 +71,16 @@ class TestFivegRFSIMProvides:
         with pytest.raises(Exception) as e:
             self.ctx.run(self.ctx.on.action("set-rfsim-information", params=params), state_in)
 
-        assert "Inconsistent scenario" in str(e.value)
+        assert "Inconsistent testing" in str(e.value)
 
     def test_given_unit_is_not_leader_when_fiveg_rfsim_relation_joined_then_data_is_not_in_application_databag(  # noqa: E501
         self,
     ):
-        fiveg_rfsim_relation = scenario.Relation(
+        fiveg_rfsim_relation = testing.Relation(
             endpoint="fiveg_rfsim",
             interface="fiveg_rfsim",
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=False,
             relations=[fiveg_rfsim_relation],
         )

--- a/tests/unit/lib/charms/oai_ran_du/v0/test_fiveg_rfsim_provider_interface.py
+++ b/tests/unit/lib/charms/oai_ran_du/v0/test_fiveg_rfsim_provider_interface.py
@@ -71,7 +71,7 @@ class TestFivegRFSIMProvides:
         with pytest.raises(Exception) as e:
             self.ctx.run(self.ctx.on.action("set-rfsim-information", params=params), state_in)
 
-        assert "Inconsistent testing" in str(e.value)
+        assert "Inconsistent scenario" in str(e.value)
 
     def test_given_unit_is_not_leader_when_fiveg_rfsim_relation_joined_then_data_is_not_in_application_databag(  # noqa: E501
         self,

--- a/tests/unit/lib/charms/oai_ran_du/v0/test_fiveg_rfsim_requirer_interface.py
+++ b/tests/unit/lib/charms/oai_ran_du/v0/test_fiveg_rfsim_requirer_interface.py
@@ -4,7 +4,7 @@
 from unittest.mock import patch
 
 import pytest
-import scenario
+from ops import testing
 
 from lib.charms.oai_ran_du_k8s.v0.fiveg_rfsim import FivegRFSIMInformationAvailableEvent
 from tests.unit.lib.charms.oai_ran_du.v0.test_charms.test_requirer_charm.src.charm import (
@@ -23,7 +23,7 @@ class TestFivegRFSIMRequires:
 
     @pytest.fixture(autouse=True)
     def context(self):
-        self.ctx = scenario.Context(
+        self.ctx = testing.Context(
             charm_type=DummyFivegRFSIMRequires,
             meta={
                 "name": "rfsim-requirer-charm",
@@ -37,14 +37,14 @@ class TestFivegRFSIMRequires:
     def test_given_fiveg_rfsim_relation_created_when_relation_changed_then_event_with_provider_rfsim_address_is_emitted(  # noqa: E501
         self,
     ):
-        fiveg_rfsim_relation = scenario.Relation(
+        fiveg_rfsim_relation = testing.Relation(
             endpoint="fiveg_rfsim",
             interface="fiveg_rfsim",
             remote_app_data={
                 "rfsim_address": "192.168.70.130",
             },
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             relations=[fiveg_rfsim_relation],
             leader=True,
         )
@@ -58,11 +58,11 @@ class TestFivegRFSIMRequires:
     def test_given_rfsim_information_not_in_relation_data_when_relation_changed_then_rfsim_information_available_event_is_not_emitted(  # noqa: E501
         self,
     ):
-        fiveg_rfsim_relation = scenario.Relation(
+        fiveg_rfsim_relation = testing.Relation(
             endpoint="fiveg_rfsim",
             interface="fiveg_rfsim",
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
             relations=[fiveg_rfsim_relation],
         )
@@ -74,14 +74,14 @@ class TestFivegRFSIMRequires:
     def test_given_rfsim_information_in_relation_data_when_get_rfsim_information_is_called_then_information_is_returned(  # noqa: E501
         self,
     ):
-        fiveg_rfsim_relation = scenario.Relation(
+        fiveg_rfsim_relation = testing.Relation(
             endpoint="fiveg_rfsim",
             interface="fiveg_rfsim",
             remote_app_data={
                 "rfsim_address": "192.168.70.130",
             },
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
             relations=[fiveg_rfsim_relation],
         )

--- a/tests/unit/test_charm_collect_status.py
+++ b/tests/unit/test_charm_collect_status.py
@@ -5,7 +5,7 @@
 import tempfile
 
 import pytest
-import scenario
+from ops import testing
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 
 from tests.unit.fixtures import DUFixtures
@@ -13,7 +13,7 @@ from tests.unit.fixtures import DUFixtures
 
 class TestCharmCollectStatus(DUFixtures):
     def test_given_unit_is_not_leader_when_collect_status_then_status_is_blocked(self):
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=False,
         )
 
@@ -37,7 +37,7 @@ class TestCharmCollectStatus(DUFixtures):
     def test_given_invalid_config_when_collect_status_then_status_is_blocked(
         self, config_param, value
     ):
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
             config={config_param: value},
         )
@@ -50,7 +50,7 @@ class TestCharmCollectStatus(DUFixtures):
 
     def test_given_multus_not_available_when_collect_status_then_status_is_blocked(self):
         self.mock_k8s_multus.multus_is_available.return_value = False
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
         )
 
@@ -63,7 +63,7 @@ class TestCharmCollectStatus(DUFixtures):
     ):
         self.mock_k8s_multus.multus_is_available.return_value = True
         self.mock_k8s_multus.is_ready.return_value = False
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
         )
 
@@ -75,7 +75,7 @@ class TestCharmCollectStatus(DUFixtures):
         self.mock_k8s_multus.multus_is_available.return_value = True
         self.mock_k8s_multus.is_ready.return_value = True
         self.mock_du_security_context.is_privileged.return_value = False
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
         )
 
@@ -88,7 +88,7 @@ class TestCharmCollectStatus(DUFixtures):
         self.mock_k8s_multus.is_ready.return_value = True
         self.mock_du_security_context.is_privileged.return_value = True
         self.mock_du_usb_volume.is_mounted.return_value = False
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
         )
 
@@ -101,7 +101,7 @@ class TestCharmCollectStatus(DUFixtures):
         self.mock_k8s_multus.is_ready.return_value = True
         self.mock_du_security_context.is_privileged.return_value = True
         self.mock_du_usb_volume.is_mounted.return_value = True
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
         )
 
@@ -114,15 +114,15 @@ class TestCharmCollectStatus(DUFixtures):
         self.mock_k8s_multus.is_ready.return_value = True
         self.mock_du_security_context.is_privileged.return_value = True
         self.mock_du_usb_volume.is_mounted.return_value = True
-        f1_relation = scenario.Relation(
+        f1_relation = testing.Relation(
             endpoint="fiveg_f1",
             interface="fiveg_f1",
         )
-        container = scenario.Container(
+        container = testing.Container(
             name="du",
             can_connect=False,
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
             relations=[f1_relation],
             containers=[container],
@@ -138,15 +138,15 @@ class TestCharmCollectStatus(DUFixtures):
         self.mock_du_security_context.is_privileged.return_value = True
         self.mock_du_usb_volume.is_mounted.return_value = True
         self.mock_check_output.return_value = b""
-        f1_relation = scenario.Relation(
+        f1_relation = testing.Relation(
             endpoint="fiveg_f1",
             interface="fiveg_f1",
         )
-        container = scenario.Container(
+        container = testing.Container(
             name="du",
             can_connect=True,
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
             relations=[f1_relation],
             containers=[container],
@@ -162,15 +162,15 @@ class TestCharmCollectStatus(DUFixtures):
         self.mock_du_security_context.is_privileged.return_value = True
         self.mock_du_usb_volume.is_mounted.return_value = True
         self.mock_check_output.return_value = b"1.2.3.4"
-        f1_relation = scenario.Relation(
+        f1_relation = testing.Relation(
             endpoint="fiveg_f1",
             interface="fiveg_f1",
         )
-        container = scenario.Container(
+        container = testing.Container(
             name="du",
             can_connect=True,
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
             relations=[f1_relation],
             containers=[container],
@@ -189,22 +189,22 @@ class TestCharmCollectStatus(DUFixtures):
             self.mock_check_output.return_value = b"1.2.3.4"
             self.mock_f1_requires_f1_ip_address.return_value = None
             self.mock_f1_requires_f1_port.return_value = None
-            f1_relation = scenario.Relation(
+            f1_relation = testing.Relation(
                 endpoint="fiveg_f1",
                 interface="fiveg_f1",
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 source=temp_dir,
                 location="/tmp/conf",
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="du",
                 can_connect=True,
                 mounts={
                     "config": config_mount,
                 },
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 relations=[f1_relation],
                 containers=[container],
@@ -223,22 +223,22 @@ class TestCharmCollectStatus(DUFixtures):
             self.mock_check_output.return_value = b"1.2.3.4"
             self.mock_f1_requires_f1_ip_address.return_value = "1.1.1.1"
             self.mock_f1_requires_f1_port.return_value = 1234
-            f1_relation = scenario.Relation(
+            f1_relation = testing.Relation(
                 endpoint="fiveg_f1",
                 interface="fiveg_f1",
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 source=temp_dir,
                 location="/tmp/conf",
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="du",
                 can_connect=True,
                 mounts={
                     "config": config_mount,
                 },
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 relations=[f1_relation],
                 containers=[container],

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -6,7 +6,7 @@
 import os
 import tempfile
 
-import scenario
+from ops import testing
 from ops.pebble import Layer
 
 from tests.unit.fixtures import DUFixtures
@@ -18,11 +18,11 @@ class TestCharmConfigure(DUFixtures):
     ):
         self.mock_du_security_context.is_privileged.return_value = False
         self.mock_du_usb_volume.is_mounted.return_value = False
-        container = scenario.Container(
+        container = testing.Container(
             name="du",
             can_connect=True,
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
             containers=[container],
         )
@@ -37,11 +37,11 @@ class TestCharmConfigure(DUFixtures):
     ):
         self.mock_du_security_context.is_privileged.return_value = False
         self.mock_du_usb_volume.is_mounted.return_value = False
-        container = scenario.Container(
+        container = testing.Container(
             name="du",
             can_connect=True,
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
             containers=[container],
             config={"simulation-mode": True},
@@ -57,11 +57,11 @@ class TestCharmConfigure(DUFixtures):
     ):
         self.mock_du_security_context.is_privileged.return_value = True
         self.mock_du_usb_volume.is_mounted.return_value = True
-        container = scenario.Container(
+        container = testing.Container(
             name="du",
             can_connect=True,
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
             containers=[container],
         )
@@ -80,26 +80,26 @@ class TestCharmConfigure(DUFixtures):
             self.mock_f1_requires_f1_ip_address.return_value = "4.3.2.1"
             self.mock_f1_requires_f1_port.return_value = 2152
             self.mock_check_output.return_value = b"1.2.3.4"
-            f1_relation = scenario.Relation(
+            f1_relation = testing.Relation(
                 endpoint="fiveg_f1",
                 interface="fiveg_f1",
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 source=temp_dir,
                 location="/tmp/conf",
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="du",
                 can_connect=True,
                 mounts={
                     "config": config_mount,
                 },
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 relations=[f1_relation],
                 containers=[container],
-                model=scenario.Model(name="whatever"),
+                model=testing.Model(name="whatever"),
             )
 
             self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
@@ -121,26 +121,26 @@ class TestCharmConfigure(DUFixtures):
             self.mock_f1_requires_f1_ip_address.return_value = "4.3.2.1"
             self.mock_f1_requires_f1_port.return_value = 2152
             self.mock_check_output.return_value = b"1.2.3.4"
-            f1_relation = scenario.Relation(
+            f1_relation = testing.Relation(
                 endpoint="fiveg_f1",
                 interface="fiveg_f1",
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 source=temp_dir,
                 location="/tmp/conf",
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="du",
                 can_connect=True,
                 mounts={
                     "config": config_mount,
                 },
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 relations=[f1_relation],
                 containers=[container],
-                model=scenario.Model(name="whatever"),
+                model=testing.Model(name="whatever"),
                 config={"simulation-mode": True},
             )
 
@@ -165,26 +165,26 @@ class TestCharmConfigure(DUFixtures):
             self.mock_f1_requires_f1_ip_address.return_value = "4.3.2.1"
             self.mock_f1_requires_f1_port.return_value = 2152
             self.mock_check_output.return_value = b"1.2.3.4"
-            f1_relation = scenario.Relation(
+            f1_relation = testing.Relation(
                 endpoint="fiveg_f1",
                 interface="fiveg_f1",
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 source=temp_dir,
                 location="/tmp/conf",
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="du",
                 can_connect=True,
                 mounts={
                     "config": config_mount,
                 },
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 relations=[f1_relation],
                 containers=[container],
-                model=scenario.Model(name="whatever"),
+                model=testing.Model(name="whatever"),
             )
             with open("tests/unit/resources/expected_config.conf") as expected_config_file:
                 expected_config = expected_config_file.read().strip()
@@ -205,26 +205,26 @@ class TestCharmConfigure(DUFixtures):
             self.mock_f1_requires_f1_ip_address.return_value = "4.3.2.1"
             self.mock_f1_requires_f1_port.return_value = 2152
             self.mock_check_output.return_value = b"1.2.3.4"
-            f1_relation = scenario.Relation(
+            f1_relation = testing.Relation(
                 endpoint="fiveg_f1",
                 interface="fiveg_f1",
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 source=temp_dir,
                 location="/tmp/conf",
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="du",
                 can_connect=True,
                 mounts={
                     "config": config_mount,
                 },
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 relations=[f1_relation],
                 containers=[container],
-                model=scenario.Model(name="whatever"),
+                model=testing.Model(name="whatever"),
             )
 
             state_out = self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
@@ -254,26 +254,26 @@ class TestCharmConfigure(DUFixtures):
             self.mock_f1_requires_f1_ip_address.return_value = "4.3.2.1"
             self.mock_f1_requires_f1_port.return_value = 2152
             self.mock_check_output.return_value = b"1.2.3.4"
-            f1_relation = scenario.Relation(
+            f1_relation = testing.Relation(
                 endpoint="fiveg_f1",
                 interface="fiveg_f1",
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 source=temp_dir,
                 location="/tmp/conf",
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="du",
                 can_connect=True,
                 mounts={
                     "config": config_mount,
                 },
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 relations=[f1_relation],
                 containers=[container],
-                model=scenario.Model(name="whatever"),
+                model=testing.Model(name="whatever"),
                 config={"simulation-mode": True},
             )
 
@@ -304,26 +304,26 @@ class TestCharmConfigure(DUFixtures):
             self.mock_f1_requires_f1_ip_address.return_value = "4.3.2.1"
             self.mock_f1_requires_f1_port.return_value = 2152
             self.mock_check_output.return_value = b"1.2.3.4"
-            f1_relation = scenario.Relation(
+            f1_relation = testing.Relation(
                 endpoint="fiveg_f1",
                 interface="fiveg_f1",
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 source=temp_dir,
                 location="/tmp/conf",
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="du",
                 can_connect=True,
                 mounts={
                     "config": config_mount,
                 },
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 relations=[f1_relation],
                 containers=[container],
-                model=scenario.Model(name="whatever"),
+                model=testing.Model(name="whatever"),
                 config={"simulation-mode": True},
             )
 
@@ -340,30 +340,30 @@ class TestCharmConfigure(DUFixtures):
             self.mock_f1_requires_f1_ip_address.return_value = "4.3.2.1"
             self.mock_f1_requires_f1_port.return_value = 2153
             self.mock_check_output.return_value = b"1.2.3.4"
-            f1_relation = scenario.Relation(
+            f1_relation = testing.Relation(
                 endpoint="fiveg_f1",
                 interface="fiveg_f1",
             )
-            rfsim_relation = scenario.Relation(
+            rfsim_relation = testing.Relation(
                 endpoint="fiveg_rfsim",
                 interface="fiveg_rfsim",
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 source=temp_dir,
                 location="/tmp/conf",
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="du",
                 can_connect=True,
                 mounts={
                     "config": config_mount,
                 },
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 relations=[f1_relation, rfsim_relation],
                 containers=[container],
-                model=scenario.Model(name="whatever"),
+                model=testing.Model(name="whatever"),
                 config={"simulation-mode": True},
             )
 

--- a/tests/unit/test_charm_fiveg_rfsim_relation_joined.py
+++ b/tests/unit/test_charm_fiveg_rfsim_relation_joined.py
@@ -4,7 +4,7 @@
 
 import tempfile
 
-import scenario
+from ops import testing
 from ops.pebble import Layer, ServiceStatus
 
 from tests.unit.fixtures import DUFixtures
@@ -14,9 +14,9 @@ class TestCharmFivegRFSIMRelationJoined(DUFixtures):
     def test_given_service_not_running_when_fiveg_rfsim_relation_joined_then_rfsim_information_is_not_in_relation_databag(  # noqa: E501
         self,
     ):
-        fiveg_rfsim_relation = scenario.Relation(endpoint="fiveg_rfsim", interface="fiveg_rfsim")
-        container = scenario.Container(name="du", can_connect=True)
-        state_in = scenario.State(
+        fiveg_rfsim_relation = testing.Relation(endpoint="fiveg_rfsim", interface="fiveg_rfsim")
+        container = testing.Container(name="du", can_connect=True)
+        state_in = testing.State(
             leader=True,
             containers=[container],
             relations=[fiveg_rfsim_relation],
@@ -38,20 +38,20 @@ class TestCharmFivegRFSIMRelationJoined(DUFixtures):
             self.mock_f1_requires_f1_ip_address.return_value = "4.3.2.1"
             self.mock_f1_requires_f1_port.return_value = 2153
             self.mock_check_output.return_value = b"1.2.3.4"
-            f1_relation = scenario.Relation(
+            f1_relation = testing.Relation(
                 endpoint="fiveg_f1",
                 interface="fiveg_f1",
             )
-            fiveg_rfsim_relation = scenario.Relation(
+            fiveg_rfsim_relation = testing.Relation(
                 endpoint="fiveg_rfsim",
                 interface="fiveg_rfsim",
                 local_app_data={"rfsim_address": "1.2.3.4"},
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 source=temp_dir,
                 location="/tmp/conf",
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="du",
                 can_connect=True,
                 layers={
@@ -73,11 +73,11 @@ class TestCharmFivegRFSIMRelationJoined(DUFixtures):
                     "config": config_mount,
                 },
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 relations=[f1_relation, fiveg_rfsim_relation],
                 containers=[container],
-                model=scenario.Model(name="whatever"),
+                model=testing.Model(name="whatever"),
                 config={"simulation-mode": True},
             )
             self.mock_rfsim_set_information.return_value = "1.2.3.4"

--- a/tests/unit/test_charm_remove.py
+++ b/tests/unit/test_charm_remove.py
@@ -3,18 +3,18 @@
 # See LICENSE file for licensing details.
 
 
-import scenario
+from ops import testing
 
 from tests.unit.fixtures import DUFixtures
 
 
 class TestCharmRemove(DUFixtures):
     def test_given_unit_is_leader_when_remove_then_k8s_multus_is_removed(self):
-        container = scenario.Container(
+        container = testing.Container(
             name="du",
             can_connect=False,
         )
-        state_in = scenario.State(leader=True, containers=[container])
+        state_in = testing.State(leader=True, containers=[container])
 
         self.ctx.run(self.ctx.on.remove(), state_in)
 


### PR DESCRIPTION
# Description

Now that scenario testing is built into ops we use ops.testing instead of directly calling scenario. Both have the same API. scenario still needs to be independently installed.


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library