### PR TITLE
feat: Use 40MHz bandwidth by default

### DIFF
--- a/src/templates/du.conf.j2
+++ b/src/templates/du.conf.j2
@@ -42,17 +42,17 @@ gNBs =
       # In this case:
       # 3925 - (20 / 2)
       # this is 3915 MHz
-      dl_absoluteFrequencyPointA                                       = 661000;
+      dl_absoluteFrequencyPointA                                       = 660332;
       #scs-SpecificCarrierList
       dl_offstToCarrier                                              = 0;
       # subcarrierSpacing
       # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
       dl_subcarrierSpacing                                           = 1;
-      dl_carrierBandwidth                                            = 51;
+      dl_carrierBandwidth                                            = 106;
       #initialDownlinkBWP
       #genericParameters
       # this is RBstart=27,L=48 (275*(L-1))+RBstart
-      initialDLBWPlocationAndBandwidth                               = 13750;
+      initialDLBWPlocationAndBandwidth                               = 28875;
       # subcarrierSpacing
       # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
       initialDLBWPsubcarrierSpacing                                   = 1;
@@ -68,11 +68,11 @@ gNBs =
       # subcarrierSpacing
       # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
       ul_subcarrierSpacing                                          = 1;
-      ul_carrierBandwidth                                           = 51;
+      ul_carrierBandwidth                                           = 106;
       pMax                                                          = 20;
       #initialUplinkBWP
       #genericParameters
-      initialULBWPlocationAndBandwidth                            = 13750;
+      initialULBWPlocationAndBandwidth                            = 28875;
       # subcarrierSpacing
       # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
       initialULBWPsubcarrierSpacing                               = 1;

--- a/tests/unit/resources/expected_config.conf
+++ b/tests/unit/resources/expected_config.conf
@@ -42,17 +42,17 @@ gNBs =
       # In this case:
       # 3925 - (20 / 2)
       # this is 3915 MHz
-      dl_absoluteFrequencyPointA                                       = 661000;
+      dl_absoluteFrequencyPointA                                       = 660332;
       #scs-SpecificCarrierList
       dl_offstToCarrier                                              = 0;
       # subcarrierSpacing
       # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
       dl_subcarrierSpacing                                           = 1;
-      dl_carrierBandwidth                                            = 51;
+      dl_carrierBandwidth                                            = 106;
       #initialDownlinkBWP
       #genericParameters
       # this is RBstart=27,L=48 (275*(L-1))+RBstart
-      initialDLBWPlocationAndBandwidth                               = 13750;
+      initialDLBWPlocationAndBandwidth                               = 28875;
       # subcarrierSpacing
       # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
       initialDLBWPsubcarrierSpacing                                   = 1;
@@ -68,11 +68,11 @@ gNBs =
       # subcarrierSpacing
       # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
       ul_subcarrierSpacing                                          = 1;
-      ul_carrierBandwidth                                           = 51;
+      ul_carrierBandwidth                                           = 106;
       pMax                                                          = 20;
       #initialUplinkBWP
       #genericParameters
-      initialULBWPlocationAndBandwidth                            = 13750;
+      initialULBWPlocationAndBandwidth                            = 28875;
       # subcarrierSpacing
       # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
       initialULBWPsubcarrierSpacing                               = 1;

--- a/tests/unit/resources/expected_rfsim_mode_config.conf
+++ b/tests/unit/resources/expected_rfsim_mode_config.conf
@@ -42,17 +42,17 @@ gNBs =
       # In this case:
       # 3925 - (20 / 2)
       # this is 3915 MHz
-      dl_absoluteFrequencyPointA                                       = 661000;
+      dl_absoluteFrequencyPointA                                       = 660332;
       #scs-SpecificCarrierList
       dl_offstToCarrier                                              = 0;
       # subcarrierSpacing
       # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
       dl_subcarrierSpacing                                           = 1;
-      dl_carrierBandwidth                                            = 51;
+      dl_carrierBandwidth                                            = 106;
       #initialDownlinkBWP
       #genericParameters
       # this is RBstart=27,L=48 (275*(L-1))+RBstart
-      initialDLBWPlocationAndBandwidth                               = 13750;
+      initialDLBWPlocationAndBandwidth                               = 28875;
       # subcarrierSpacing
       # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
       initialDLBWPsubcarrierSpacing                                   = 1;
@@ -68,11 +68,11 @@ gNBs =
       # subcarrierSpacing
       # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
       ul_subcarrierSpacing                                          = 1;
-      ul_carrierBandwidth                                           = 51;
+      ul_carrierBandwidth                                           = 106;
       pMax                                                          = 20;
       #initialUplinkBWP
       #genericParameters
-      initialULBWPlocationAndBandwidth                            = 13750;
+      initialULBWPlocationAndBandwidth                            = 28875;
       # subcarrierSpacing
       # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
       initialULBWPsubcarrierSpacing                               = 1;


### PR DESCRIPTION
# Description

Change the DU configuration to use 40MHz bandwidth for more speed while testing performance with SD-Core.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library