### PR TITLE
feat: extend fiveg_rfsim interface

### DIFF
--- a/lib/charms/oai_ran_du_k8s/v0/fiveg_rfsim.py
+++ b/lib/charms/oai_ran_du_k8s/v0/fiveg_rfsim.py
@@ -5,7 +5,7 @@
 
 This library contains the Requires and Provides classes for handling the `fiveg_rfsim` interface.
 
-The purpose of this library is to relate two charms to pass the RF SIM address.
+The purpose of this library is to relate two charms to pass the RF SIM address and network information (SST and SD).
 In the Telco world this will typically be charms implementing
 the DU (Distributed Unit) and the UE (User equipment).
 
@@ -21,14 +21,14 @@ Add the following libraries to the charm's `requirements.txt` file:
 - pytest-interface-tester
 
 ### Provider charm
-The provider charm is the one providing the information about RF SIM address.
+The provider charm is the one providing the information about RF SIM address, Network Slice Type (SST) and Network Differentiator (SD).
 Typically, this will be the DU charm.
 
 Example:
 ```python
 
+from ops import main
 from ops.charm import CharmBase, RelationJoinedEvent
-from ops.main import main
 
 from charms.oai_ran_du_k8s.v0.fiveg_rfsim import RFSIMProvides
 
@@ -36,6 +36,8 @@ from charms.oai_ran_du_k8s.v0.fiveg_rfsim import RFSIMProvides
 class DummyFivegRFSIMProviderCharm(CharmBase):
 
     RFSIM_ADDRESS = "192.168.70.130"
+    SST = 1
+    SD = 1
 
     def __init__(self, *args):
         super().__init__(*args)
@@ -48,6 +50,8 @@ class DummyFivegRFSIMProviderCharm(CharmBase):
         if self.unit.is_leader():
             self.rfsim_provider.set_rfsim_information(
                 rfsim_address=self.RFSIM_ADDRESS
+                sst=self.SST,
+                sd=self.SD,
             )
 
 
@@ -62,10 +66,10 @@ Typically, this will be the UE charm.
 Example:
 ```python
 
-from ops.charm import CharmBase
-from ops.main import main
+from ops import main
+from ops.charm import CharmBase, RelationChangedEvent
 
-from charms.oai_ran_du_k8s.v0.fiveg_rfsim import FivegRFSIMInformationAvailableEvent, RFSIMRequires
+from charms.oai_ran_du_k8s.v0.fiveg_rfsim import RFSIMRequires
 
 logger = logging.getLogger(__name__)
 
@@ -76,12 +80,14 @@ class DummyFivegRFSIMRequires(CharmBase):
         super().__init__(*args)
         self.rfsim_requirer = RFSIMRequires(self, "fiveg_rfsim")
         self.framework.observe(
-            self.rfsim_requirer.on.fiveg_rfsim_provider_available, self._on_rfsim_information_available
+            self.on.fiveg_rfsim_relation_changed, self._on_fiveg_rfsim_relation_changed
         )
 
-    def _on_rfsim_information_available(self, event: FivegRFSIMInformationAvailableEvent):
+    def _on_fiveg_rfsim_relation_changed(self, event: RelationChangedEvent):
         provider_rfsim_address = event.rfsim_address
-        <do something with the rfsim address here>
+        provider_sst = event.sst
+        provider_st = event.sd
+        <do something with the rfsim address, SST and SD here>
 
 
 if __name__ == "__main__":
@@ -95,10 +101,10 @@ import logging
 from typing import Any, Dict, Optional
 
 from interface_tester.schema_base import DataBagSchema
-from ops.charm import CharmBase, CharmEvents, RelationChangedEvent
-from ops.framework import EventBase, EventSource, Handle, Object
+from ops.charm import CharmBase
+from ops.framework import Object
 from ops.model import Relation
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, Field, IPvAnyAddress, ValidationError
 
 
 # The unique Charmhub library identifier, never change it
@@ -109,25 +115,55 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 
 logger = logging.getLogger(__name__)
 
+"""Schemas definition for the provider and requirer sides of the `fiveg_rfsim` interface.
+It exposes two interface_tester.schema_base.DataBagSchema subclasses called:
+- ProviderSchema
+- RequirerSchema
+Examples:
+    ProviderSchema:
+        unit: <empty>
+        app: {
+            "rfsim_address": "192.168.70.130",
+            "sst": 1,
+            "sd": 1,
+        }
+    RequirerSchema:
+        unit: <empty>
+        app:  <empty>
+"""
 
-class FivegRFSIMProviderAppData(BaseModel):
+
+class ProviderAppData(BaseModel):
     """Provider app data for fiveg_rfsim."""
 
-    rfsim_address: str = Field(
+    rfsim_address: IPvAnyAddress = Field(
         description="RF simulator service address which is equal to DU pod ip",
         examples=["192.168.70.130"],
+    )
+    sst: int = Field(
+        description="Slice/Service Type",
+        examples=[1, 2, 3, 4],
+        ge=0,
+        le=255,
+    )
+    sd: Optional[int] = Field(
+        description="Slice Differentiator",
+        default=None,
+        examples=[1],
+        ge=0,
+        le=16777215,
     )
 
 
 class ProviderSchema(DataBagSchema):
     """Provider schema for the fiveg_rfsim interface."""
 
-    app: FivegRFSIMProviderAppData
+    app_data: ProviderAppData
 
 
 def provider_data_is_valid(data: Dict[str, Any]) -> bool:
@@ -140,39 +176,11 @@ def provider_data_is_valid(data: Dict[str, Any]) -> bool:
         bool: True if data is valid, False otherwise.
     """
     try:
-        ProviderSchema(app=data)
+        ProviderSchema(app_data=ProviderAppData(**data))
         return True
     except ValidationError as e:
         logger.error("Invalid data: %s", e)
         return False
-
-
-class FivegRFSIMInformationAvailableEvent(EventBase):
-    """Charm event emitted when the RFSIM provider info is available.
-
-    The event carries the RFSIM provider's address.
-    """
-
-    def __init__(self, handle: Handle, rfsim_address: str):
-        """Init."""
-        super().__init__(handle)
-        self.rfsim_address = rfsim_address
-
-    def snapshot(self) -> dict:
-        """Return snapshot."""
-        return {
-            "rfsim_address": self.rfsim_address,
-        }
-
-    def restore(self, snapshot: dict) -> None:
-        """Restores snapshot."""
-        self.rfsim_address = snapshot["rfsim_address"]
-
-
-class FivegRFSIMRequirerCharmEvents(CharmEvents):
-    """The event that the RFSIM requirer charm can leverage."""
-
-    fiveg_rfsim_provider_available = EventSource(FivegRFSIMInformationAvailableEvent)
 
 
 class FivegRFSIMError(Exception):
@@ -192,49 +200,45 @@ class RFSIMProvides(Object):
         self.relation_name = relation_name
         self.charm = charm
 
-    def set_rfsim_information(self, rfsim_address: str) -> None:
+    def set_rfsim_information(self, rfsim_address: str, sst: int, sd: Optional[int]) -> None:
         """Push the information about the RFSIM interface in the application relation data.
 
         Args:
             rfsim_address (str): rfsim service address which is equal to DU pod ip.
+            sst (int): Slice/Service Type
+            sd (Optional[int]): Slice Differentiator
         """
         if not self.charm.unit.is_leader():
             raise FivegRFSIMError("Unit must be leader to set application relation data.")
         relations = self.model.relations[self.relation_name]
         if not relations:
             raise FivegRFSIMError(f"Relation {self.relation_name} not created yet.")
-        if not provider_data_is_valid({"rfsim_address": rfsim_address}):
+        if not provider_data_is_valid(
+            {
+                "rfsim_address": rfsim_address,
+                "sst": sst,
+                "sd": sd,
+            }
+        ):
             raise FivegRFSIMError("Invalid relation data")
         for relation in relations:
-            relation.data[self.charm.app].update(
-                {
-                    "rfsim_address": rfsim_address,
-                }
-            )
+            data = {
+                "rfsim_address": rfsim_address,
+                "sst": str(sst),
+            }
+            if sd is not None:
+                data["sd"] = str(sd)
+            relation.data[self.charm.app].update(data)
 
 
 class RFSIMRequires(Object):
     """Class to be instantiated by the charm requiring relation using the `fiveg_rfsim` interface."""
-
-    on = FivegRFSIMRequirerCharmEvents()
 
     def __init__(self, charm: CharmBase, relation_name: str):
         """Init."""
         super().__init__(charm, relation_name)
         self.charm = charm
         self.relation_name = relation_name
-        self.framework.observe(charm.on[relation_name].relation_changed, self._on_relation_changed)
-
-    def _on_relation_changed(self, event: RelationChangedEvent) -> None:
-        """Handle relation changed event.
-
-        Args:
-            event (RelationChangedEvent): Juju event.
-        """
-        if remote_app_relation_data := self._get_remote_app_relation_data(event.relation):
-            self.on.fiveg_rfsim_provider_available.emit(
-                rfsim_address=remote_app_relation_data["rfsim_address"],
-            )
 
     @property
     def rfsim_address(self) -> Optional[str]:
@@ -243,21 +247,42 @@ class RFSIMRequires(Object):
         Returns:
             str: rfsim address which is equal to DU pod ip.
         """
-        if remote_app_relation_data := self._get_remote_app_relation_data():
+        if remote_app_relation_data := self.get_provider_rfsim_information():
             return remote_app_relation_data.get("rfsim_address")
         return None
 
-    def _get_remote_app_relation_data(
-        self, relation: Optional[Relation] = None
-    ) -> Optional[Dict[str, str]]:
+    @property
+    def sst(self) -> Optional[str]:
+        """Return the Network Slice Service Type (SST).
+
+        Returns:
+            str: sst (Network Slice Service Type)
+        """
+        if remote_app_relation_data := self.get_provider_rfsim_information():
+            return remote_app_relation_data.get("sst")
+        return None
+
+    @property
+    def sd(self) -> Optional[str]:
+        """Return the Network Slice Differentiator (SD).
+
+        Returns:
+            str: sd (Network Slice Differentiator)
+        """
+        if remote_app_relation_data := self.get_provider_rfsim_information():
+            return remote_app_relation_data.get("sd")
+        return None
+
+    def get_provider_rfsim_information(self, relation: Optional[Relation] = None
+    ) -> Optional[ProviderAppData]:
         """Get relation data for the remote application.
 
         Args:
             relation: Juju relation object (optional).
 
         Returns:
-            Dict: Relation data for the remote application
-            or None if the relation data is invalid.
+            ProviderAppData: Relation data for the remote application if data is valid,
+            None otherwise.
         """
         relation = relation or self.model.get_relation(self.relation_name)
         if not relation:
@@ -266,8 +291,16 @@ class RFSIMRequires(Object):
         if not relation.app:
             logger.warning("No remote application in relation: %s", self.relation_name)
             return None
-        remote_app_relation_data = dict(relation.data[relation.app])
-        if not provider_data_is_valid(remote_app_relation_data):
+        remote_app_relation_data: Dict[str, Any] = dict(relation.data[relation.app])
+        try:
+            remote_app_relation_data["sd"] = int(remote_app_relation_data.get("sd", ""))
+            remote_app_relation_data["sst"] = int(remote_app_relation_data.get("sst", ""))
+        except ValueError:
             logger.error("Invalid relation data: %s", remote_app_relation_data)
             return None
-        return remote_app_relation_data
+        try:
+            provider_app_data = ProviderAppData(**remote_app_relation_data)
+        except ValidationError:
+            logger.error("Invalid relation data: %s", remote_app_relation_data)
+            return None
+        return provider_app_data

--- a/lib/charms/oai_ran_du_k8s/v0/fiveg_rfsim.py
+++ b/lib/charms/oai_ran_du_k8s/v0/fiveg_rfsim.py
@@ -245,7 +245,7 @@ class RFSIMRequires(Object):
         """Return address of the RFSIM.
 
         Returns:
-            str: rfsim address which is equal to DU pod ip.
+            Optional[IPvAnyAddress]: rfsim address which is equal to DU pod ip.
         """
         if remote_app_relation_data := self.get_provider_rfsim_information():
             return remote_app_relation_data.rfsim_address
@@ -256,7 +256,7 @@ class RFSIMRequires(Object):
         """Return the Network Slice Service Type (SST).
 
         Returns:
-            str: sst (Network Slice Service Type)
+            Optional[int]: sst (Network Slice Service Type)
         """
         if remote_app_relation_data := self.get_provider_rfsim_information():
             return remote_app_relation_data.sst
@@ -267,7 +267,7 @@ class RFSIMRequires(Object):
         """Return the Network Slice Differentiator (SD).
 
         Returns:
-            str: sd (Network Slice Differentiator)
+           Optional[int] : sd (Network Slice Differentiator)
         """
         if remote_app_relation_data := self.get_provider_rfsim_information():
             return remote_app_relation_data.sd

--- a/lib/charms/oai_ran_du_k8s/v0/fiveg_rfsim.py
+++ b/lib/charms/oai_ran_du_k8s/v0/fiveg_rfsim.py
@@ -248,7 +248,7 @@ class RFSIMRequires(Object):
             str: rfsim address which is equal to DU pod ip.
         """
         if remote_app_relation_data := self.get_provider_rfsim_information():
-            return remote_app_relation_data.get("rfsim_address")
+            return remote_app_relation_data.rfsim_address
         return None
 
     @property
@@ -259,7 +259,7 @@ class RFSIMRequires(Object):
             str: sst (Network Slice Service Type)
         """
         if remote_app_relation_data := self.get_provider_rfsim_information():
-            return remote_app_relation_data.get("sst")
+            return remote_app_relation_data.sst
         return None
 
     @property
@@ -270,7 +270,7 @@ class RFSIMRequires(Object):
             str: sd (Network Slice Differentiator)
         """
         if remote_app_relation_data := self.get_provider_rfsim_information():
-            return remote_app_relation_data.get("sd")
+            return remote_app_relation_data.sd
         return None
 
     def get_provider_rfsim_information(self, relation: Optional[Relation] = None

--- a/lib/charms/oai_ran_du_k8s/v0/fiveg_rfsim.py
+++ b/lib/charms/oai_ran_du_k8s/v0/fiveg_rfsim.py
@@ -28,7 +28,7 @@ Example:
 ```python
 
 from ops import main
-from ops.charm import CharmBase, RelationJoinedEvent
+from ops.charm import CharmBase, RelationChangedEvent
 
 from charms.oai_ran_du_k8s.v0.fiveg_rfsim import RFSIMProvides
 
@@ -43,10 +43,10 @@ class DummyFivegRFSIMProviderCharm(CharmBase):
         super().__init__(*args)
         self.rfsim_provider = RFSIMProvides(self, "fiveg_rfsim")
         self.framework.observe(
-            self.on.fiveg_rfsim_relation_joined, self._on_fiveg_rfsim_relation_joined
+            self.on.fiveg_rfsim_relation_changed, self._on_fiveg_rfsim_relation_changed
         )
 
-    def _on_fiveg_rfsim_relation_joined(self, event: RelationJoinedEvent):
+    def _on_fiveg_rfsim_relation_changed(self, event: RelationChangedEvent):
         if self.unit.is_leader():
             self.rfsim_provider.set_rfsim_information(
                 rfsim_address=self.RFSIM_ADDRESS

--- a/lib/charms/oai_ran_du_k8s/v0/fiveg_rfsim.py
+++ b/lib/charms/oai_ran_du_k8s/v0/fiveg_rfsim.py
@@ -252,7 +252,7 @@ class RFSIMRequires(Object):
         return None
 
     @property
-    def sst(self) -> Optional[str]:
+    def sst(self) -> Optional[int]:
         """Return the Network Slice Service Type (SST).
 
         Returns:
@@ -263,7 +263,7 @@ class RFSIMRequires(Object):
         return None
 
     @property
-    def sd(self) -> Optional[str]:
+    def sd(self) -> Optional[int]:
         """Return the Network Slice Differentiator (SD).
 
         Returns:

--- a/lib/charms/oai_ran_du_k8s/v0/fiveg_rfsim.py
+++ b/lib/charms/oai_ran_du_k8s/v0/fiveg_rfsim.py
@@ -241,7 +241,7 @@ class RFSIMRequires(Object):
         self.relation_name = relation_name
 
     @property
-    def rfsim_address(self) -> Optional[str]:
+    def rfsim_address(self) -> Optional[IPvAnyAddress]:
         """Return address of the RFSIM.
 
         Returns:

--- a/src/charm.py
+++ b/src/charm.py
@@ -88,7 +88,7 @@ class OAIRANDUOperator(CharmBase):
         self.framework.observe(self.on.du_pebble_ready, self._configure)
         self.framework.observe(self.on[F1_RELATION_NAME].relation_created, self._configure)
         self.framework.observe(self.on[F1_RELATION_NAME].relation_changed, self._configure)
-        self.framework.observe(self.on.fiveg_rfsim_relation_joined, self._configure)
+        self.framework.observe(self.on[RFSIM_RELATION_NAME].relation_joined, self._configure)
         self.framework.observe(self.on.remove, self._on_remove)
 
     def _on_collect_unit_status(self, event: CollectStatusEvent):  # noqa C901
@@ -211,7 +211,13 @@ class OAIRANDUOperator(CharmBase):
             return
         if not self._get_rfsim_address():
             return
-        self.rfsim_provider.set_rfsim_information(self._get_rfsim_address())
+        if not self._get_sst():
+            return
+        self.rfsim_provider.set_rfsim_information(
+            self._get_rfsim_address(),
+            self._get_sst(),
+            self._get_sd(),
+        )
 
     @staticmethod
     def _get_rfsim_address() -> str:
@@ -224,6 +230,26 @@ class OAIRANDUOperator(CharmBase):
         if _get_pod_ip():
             return str(_get_pod_ip())
         return ""
+
+    @staticmethod
+    def _get_sst() -> int:
+        """Return the Network Slice SST if sst exists.
+
+        Returns:
+            int/None: If fiveg_f1 relation is created and sst exists else None
+        """
+        # TODO Implement after fiveg_f1 relation is implemented
+        return 1
+
+    @staticmethod
+    def _get_sd() -> Optional[int]:
+        """Return the Network Slice Differentiator if fiveg_f1 relation is set up and sd exits.
+
+        Returns:
+            int/None: If fiveg_f1 relation is created and sd exists else None
+        """
+        # TODO Implement after fiveg_f1 relation is implemented
+        return None
 
     def _du_service_is_running(self) -> bool:
         """Return whether the DU service is running.

--- a/src/charm.py
+++ b/src/charm.py
@@ -88,7 +88,7 @@ class OAIRANDUOperator(CharmBase):
         self.framework.observe(self.on.du_pebble_ready, self._configure)
         self.framework.observe(self.on[F1_RELATION_NAME].relation_created, self._configure)
         self.framework.observe(self.on[F1_RELATION_NAME].relation_changed, self._configure)
-        self.framework.observe(self.on[RFSIM_RELATION_NAME].relation_joined, self._configure)
+        self.framework.observe(self.on[RFSIM_RELATION_NAME].relation_changed, self._configure)
         self.framework.observe(self.on.remove, self._on_remove)
 
     def _on_collect_unit_status(self, event: CollectStatusEvent):  # noqa C901

--- a/src/charm.py
+++ b/src/charm.py
@@ -211,12 +211,19 @@ class OAIRANDUOperator(CharmBase):
             return
         if not self._get_rfsim_address():
             return
-        if not self._get_sst():
+        if not self._relation_created(F1_RELATION_NAME):
+            return
+        if not (remote_network_information := self._f1_requirer.get_provider_f1_information()):
+            return
+        # There could be multiple PLMNs but UE simulator always publishes the first PLMN content
+        # according to Spec TE126. For real UE's, the device group of a slice includes IMSI
+        # which can be associated with a UE.
+        if not remote_network_information.plmns:
             return
         self.rfsim_provider.set_rfsim_information(
             self._get_rfsim_address(),
-            self._get_sst(),
-            self._get_sd(),
+            remote_network_information.plmns[0].sst,
+            remote_network_information.plmns[0].sd,
         )
 
     @staticmethod
@@ -230,26 +237,6 @@ class OAIRANDUOperator(CharmBase):
         if _get_pod_ip():
             return str(_get_pod_ip())
         return ""
-
-    @staticmethod
-    def _get_sst() -> int:
-        """Return the Network Slice SST if sst exists.
-
-        Returns:
-            int/None: If fiveg_f1 relation is created and sst exists else None
-        """
-        # TODO Implement after fiveg_f1 relation is implemented
-        return 1
-
-    @staticmethod
-    def _get_sd() -> Optional[int]:
-        """Return the Network Slice Differentiator if fiveg_f1 relation is set up and sd exits.
-
-        Returns:
-            int/None: If fiveg_f1 relation is created and sd exists else None
-        """
-        # TODO Implement after fiveg_f1 relation is implemented
-        return None
 
     def _du_service_is_running(self) -> bool:
         """Return whether the DU service is running.

--- a/tests/unit/fixtures.py
+++ b/tests/unit/fixtures.py
@@ -18,6 +18,13 @@ F1_PROVIDER_DATA = ProviderAppData(
     plmns=[PLMNConfig(mcc="001", mnc="01", sst=1)],
 )
 
+F1_PROVIDER_DATA_WITH_SD = ProviderAppData(
+    f1_ip_address=IPv4Address("4.3.2.1"),
+    f1_port=2152,
+    tac=1,
+    plmns=[PLMNConfig(mcc="001", mnc="01", sst=1, sd=1)],
+)
+
 
 class DUFixtures:
     patcher_check_output = patch("charm.check_output")

--- a/tests/unit/lib/charms/oai_ran_du/v0/test_charms/test_provider_charm/src/charm.py
+++ b/tests/unit/lib/charms/oai_ran_du/v0/test_charms/test_provider_charm/src/charm.py
@@ -3,8 +3,8 @@
 
 import logging
 
+from ops import main
 from ops.charm import ActionEvent, CharmBase
-from ops.main import main
 
 from lib.charms.oai_ran_du_k8s.v0.fiveg_rfsim import RFSIMProvides
 
@@ -23,8 +23,22 @@ class DummyFivegRFSIMProviderCharm(CharmBase):
 
     def _on_set_rfsim_information_action(self, event: ActionEvent):
         rfsim_address = event.params.get("rfsim_address", "")
+        sst = event.params.get("sst", "")
+        sd = event.params.get("sd", "")
         self.rfsim_provider.set_rfsim_information(
             rfsim_address=rfsim_address,
+            sst=int(sst),
+            sd=int(sd) if sd else None,
+        )
+
+    def _on_set_rfsim_information_as_string_action(self, event: ActionEvent):
+        rfsim_address = event.params.get("rfsim_address", "")
+        sst = event.params.get("sst", "")
+        sd = event.params.get("sd", "")
+        self.rfsim_provider.set_rfsim_information(
+            rfsim_address=rfsim_address,
+            sst=sst,
+            sd=sd if sd else None,
         )
 
 

--- a/tests/unit/lib/charms/oai_ran_du/v0/test_charms/test_requirer_charm/src/charm.py
+++ b/tests/unit/lib/charms/oai_ran_du/v0/test_charms/test_requirer_charm/src/charm.py
@@ -1,12 +1,11 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-from ops.charm import ActionEvent, CharmBase
-from ops.main import main
 
-from lib.charms.oai_ran_du_k8s.v0.fiveg_rfsim import (
-    RFSIMRequires,
-)
+from ops import main
+from ops.charm import ActionEvent, CharmBase
+
+from lib.charms.oai_ran_du_k8s.v0.fiveg_rfsim import ProviderAppData, RFSIMRequires
 
 
 class DummyFivegRFSIMRequires(CharmBase):
@@ -18,13 +17,25 @@ class DummyFivegRFSIMRequires(CharmBase):
         self.framework.observe(
             self.on.get_rfsim_information_action, self._on_get_rfsim_information_action
         )
+        self.framework.observe(
+            self.on.get_rfsim_information_invalid_action,
+            self._on_get_rfsim_information_invalid_action,
+        )
 
     def _on_get_rfsim_information_action(self, event: ActionEvent):
-        event.set_results(
-            results={
-                "rfsim-address": self.rfsim_requirer.rfsim_address,
-            }
-        )
+        rfsim_address = event.params.get("expected_rfsim_address", "")
+        sst = event.params.get("expected_sst", "")
+        sd = event.params.get("expected_sd", "")
+        data = {
+            "rfsim_address": rfsim_address,
+            "sst": int(sst),
+            "sd": int(sd),
+        }
+        provider_app_data = ProviderAppData(**data)
+        assert provider_app_data == self.rfsim_requirer.get_provider_rfsim_information()
+
+    def _on_get_rfsim_information_invalid_action(self, event: ActionEvent):
+        assert self.rfsim_requirer.get_provider_rfsim_information() is None
 
 
 if __name__ == "__main__":

--- a/tests/unit/lib/charms/oai_ran_du/v0/test_fiveg_rfsim_provider_interface.py
+++ b/tests/unit/lib/charms/oai_ran_du/v0/test_fiveg_rfsim_provider_interface.py
@@ -1,8 +1,6 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-from unittest.mock import patch
-
 import pytest
 from ops import testing
 
@@ -10,16 +8,12 @@ from tests.unit.lib.charms.oai_ran_du.v0.test_charms.test_provider_charm.src.cha
     DummyFivegRFSIMProviderCharm,
 )
 
+VALID_RFSIM_ADDRESS = "192.168.70.130"
+VALID_SST = "1"
+VALID_SD = "1"
+
 
 class TestFivegRFSIMProvides:
-    @pytest.fixture(autouse=True)
-    def setUp(self, request):
-        yield
-        request.addfinalizer(self.tearDown)
-
-    def tearDown(self) -> None:
-        patch.stopall()
-
     @pytest.fixture(autouse=True)
     def context(self):
         self.ctx = testing.Context(
@@ -29,7 +23,20 @@ class TestFivegRFSIMProvides:
                 "provides": {"fiveg_rfsim": {"interface": "fiveg_rfsim"}},
             },
             actions={
-                "set-rfsim-information": {"params": {"rfsim_address": {"type": "string"}}},
+                "set-rfsim-information": {
+                    "params": {
+                        "rfsim_address": {"type": "string"},
+                        "sst": {"type": "string"},
+                        "sd": {"type": "string"},
+                    }
+                },
+                "set-rfsim-information-as-string": {
+                    "params": {
+                        "rfsim_address": {"type": "string"},
+                        "sst": {"type": "string"},
+                        "sd": {"type": "string"},
+                    }
+                },
             },
         )
 
@@ -45,7 +52,9 @@ class TestFivegRFSIMProvides:
             leader=True,
         )
         params = {
-            "rfsim_address": "1.2.3.4",
+            "rfsim_address": VALID_RFSIM_ADDRESS,
+            "sst": VALID_SST,
+            "sd": VALID_SD,
         }
 
         state_out = self.ctx.run(
@@ -53,9 +62,13 @@ class TestFivegRFSIMProvides:
         )
 
         relation = state_out.get_relation(fiveg_rfsim_relation.id)
-        assert relation.local_app_data == {"rfsim_address": "1.2.3.4"}
+        assert relation.local_app_data["rfsim_address"] == VALID_RFSIM_ADDRESS
+        assert relation.local_app_data["sst"] == VALID_SST
+        assert relation.local_app_data["sd"] == VALID_SD
 
-    def test_given_invalid_rfsim_address_when_set_rfsim_information_then_error_is_raised(self):
+    def test_given_no_sd_when_set_rfsim_information_then_rfsim_data_is_pushed_to_the_relation_databag_without_sd(  # noqa: E501
+        self,
+    ):
         fiveg_rfsim_relation = testing.Relation(
             endpoint="fiveg_rfsim",
             interface="fiveg_rfsim",
@@ -65,13 +78,78 @@ class TestFivegRFSIMProvides:
             leader=True,
         )
         params = {
-            "rfsim_address": 1111,
+            "rfsim_address": VALID_RFSIM_ADDRESS,
+            "sst": VALID_SST,
+        }
+
+        state_out = self.ctx.run(
+            self.ctx.on.action("set-rfsim-information", params=params), state_in
+        )
+
+        relation = state_out.get_relation(fiveg_rfsim_relation.id)
+        assert relation.local_app_data["rfsim_address"] == VALID_RFSIM_ADDRESS
+        assert relation.local_app_data["sst"] == VALID_SST
+        assert relation.local_app_data.get("sd") is None
+
+    @pytest.mark.parametrize(
+        "rfsim_address",
+        [
+            pytest.param("1111", id="invalid_rfsim_address"),
+            pytest.param("", id="empty_rfsim_address"),
+        ],
+    )
+    def test_given_invalid_rfsim_address_when_set_rfsim_information_then_error_is_raised(
+        self, rfsim_address
+    ):
+        fiveg_rfsim_relation = testing.Relation(
+            endpoint="fiveg_rfsim",
+            interface="fiveg_rfsim",
+        )
+        state_in = testing.State(
+            relations=[fiveg_rfsim_relation],
+            leader=True,
+        )
+        params = {
+            "rfsim_address": rfsim_address,
+            "sst": VALID_SST,
+            "sd": VALID_SD,
         }
 
         with pytest.raises(Exception) as e:
             self.ctx.run(self.ctx.on.action("set-rfsim-information", params=params), state_in)
 
-        assert "Inconsistent scenario" in str(e.value)
+        assert "Invalid relation data" in str(e.value)
+
+    @pytest.mark.parametrize(
+        "sst,sd",
+        [
+            pytest.param(VALID_SST, "-1", id="too_small_sd"),
+            pytest.param(VALID_SST, "16777216", id="too_large_sd"),
+            pytest.param("-1", VALID_SD, id="too_small_sst"),
+            pytest.param("256", VALID_SD, id="too_large_sst"),
+        ],
+    )
+    def test_given_invalid_sst_and_sd_when_set_rfsim_information_then_error_is_raised(
+        self, sst, sd
+    ):
+        fiveg_rfsim_relation = testing.Relation(
+            endpoint="fiveg_rfsim",
+            interface="fiveg_rfsim",
+        )
+        state_in = testing.State(
+            relations=[fiveg_rfsim_relation],
+            leader=True,
+        )
+        params = {
+            "rfsim_address": VALID_RFSIM_ADDRESS,
+            "sst": sst,
+            "sd": sd,
+        }
+
+        with pytest.raises(Exception) as e:
+            self.ctx.run(self.ctx.on.action("set-rfsim-information", params=params), state_in)
+
+        assert "Invalid relation data" in str(e.value)
 
     def test_given_unit_is_not_leader_when_fiveg_rfsim_relation_joined_then_data_is_not_in_application_databag(  # noqa: E501
         self,
@@ -85,10 +163,27 @@ class TestFivegRFSIMProvides:
             relations=[fiveg_rfsim_relation],
         )
         params = {
-            "rfsim_address": "1.2.3.4",
+            "rfsim_address": VALID_RFSIM_ADDRESS,
+            "sst": VALID_SST,
+            "sd": VALID_SD,
         }
 
         with pytest.raises(Exception) as e:
             self.ctx.run(self.ctx.on.action("set-rfsim-information", params=params), state_in)
 
         assert "Unit must be leader" in str(e.value)
+
+    def test_given_rfsim_relation_does_not_exist_when_set_rfsim_information_then_error_is_raised(  # noqa: E501
+        self,
+    ):
+        state_in = testing.State(relations=[], leader=True)
+        params = {
+            "rfsim_address": VALID_RFSIM_ADDRESS,
+            "sst": VALID_SST,
+            "sd": VALID_SD,
+        }
+
+        with pytest.raises(Exception) as e:
+            self.ctx.run(self.ctx.on.action("set-rfsim-information", params=params), state_in)
+
+        assert "Relation fiveg_rfsim not created yet." in str(e.value)

--- a/tests/unit/lib/charms/oai_ran_du/v0/test_fiveg_rfsim_requirer_interface.py
+++ b/tests/unit/lib/charms/oai_ran_du/v0/test_fiveg_rfsim_requirer_interface.py
@@ -1,26 +1,20 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-from unittest.mock import patch
 
 import pytest
 from ops import testing
 
-from lib.charms.oai_ran_du_k8s.v0.fiveg_rfsim import FivegRFSIMInformationAvailableEvent
 from tests.unit.lib.charms.oai_ran_du.v0.test_charms.test_requirer_charm.src.charm import (
     DummyFivegRFSIMRequires,
 )
 
+VALID_RFSIM_ADDRESS = "192.168.70.130"
+VALID_SST = "1"
+VALID_SD = "1"
+
 
 class TestFivegRFSIMRequires:
-    @pytest.fixture(autouse=True)
-    def setUp(self, request):
-        yield
-        request.addfinalizer(self.tearDown)
-
-    def tearDown(self) -> None:
-        patch.stopall()
-
     @pytest.fixture(autouse=True)
     def context(self):
         self.ctx = testing.Context(
@@ -30,46 +24,16 @@ class TestFivegRFSIMRequires:
                 "requires": {"fiveg_rfsim": {"interface": "fiveg_rfsim"}},
             },
             actions={
-                "get-rfsim-information": {"params": {}},
+                "get-rfsim-information": {
+                    "params": {
+                        "expected_rfsim_address": {"type": "string"},
+                        "expected_sst": {"type": "integer"},
+                        "expected_sd": {"type": "integer"},
+                    }
+                },
+                "get-rfsim-information-invalid": {"params": {}},
             },
         )
-
-    def test_given_fiveg_rfsim_relation_created_when_relation_changed_then_event_with_provider_rfsim_address_is_emitted(  # noqa: E501
-        self,
-    ):
-        fiveg_rfsim_relation = testing.Relation(
-            endpoint="fiveg_rfsim",
-            interface="fiveg_rfsim",
-            remote_app_data={
-                "rfsim_address": "192.168.70.130",
-            },
-        )
-        state_in = testing.State(
-            relations=[fiveg_rfsim_relation],
-            leader=True,
-        )
-
-        self.ctx.run(self.ctx.on.relation_changed(fiveg_rfsim_relation), state_in)
-
-        assert len(self.ctx.emitted_events) == 2
-        assert isinstance(self.ctx.emitted_events[1], FivegRFSIMInformationAvailableEvent)
-        assert self.ctx.emitted_events[1].rfsim_address == "192.168.70.130"
-
-    def test_given_rfsim_information_not_in_relation_data_when_relation_changed_then_rfsim_information_available_event_is_not_emitted(  # noqa: E501
-        self,
-    ):
-        fiveg_rfsim_relation = testing.Relation(
-            endpoint="fiveg_rfsim",
-            interface="fiveg_rfsim",
-        )
-        state_in = testing.State(
-            leader=True,
-            relations=[fiveg_rfsim_relation],
-        )
-
-        self.ctx.run(self.ctx.on.relation_changed(fiveg_rfsim_relation), state_in)
-
-        assert len(self.ctx.emitted_events) == 1
 
     def test_given_rfsim_information_in_relation_data_when_get_rfsim_information_is_called_then_information_is_returned(  # noqa: E501
         self,
@@ -78,15 +42,65 @@ class TestFivegRFSIMRequires:
             endpoint="fiveg_rfsim",
             interface="fiveg_rfsim",
             remote_app_data={
-                "rfsim_address": "192.168.70.130",
+                "rfsim_address": VALID_RFSIM_ADDRESS,
+                "sst": VALID_SST,
+                "sd": VALID_SD,
             },
         )
         state_in = testing.State(
             leader=True,
             relations=[fiveg_rfsim_relation],
         )
+        params = {
+            "expected_rfsim_address": VALID_RFSIM_ADDRESS,
+            "expected_sst": int(VALID_SST),
+            "expected_sd": int(VALID_SD),
+        }
+        self.ctx.run(self.ctx.on.action("get-rfsim-information", params=params), state_in)
 
-        self.ctx.run(self.ctx.on.action("get-rfsim-information"), state_in)
+    @pytest.mark.parametrize(
+        "remote_data",
+        [
+            pytest.param(
+                {
+                    "rfsim_address": "1111",
+                    "sst": VALID_SST,
+                    "sd": VALID_SD,
+                },
+                id="invalid_rfsim_address",
+            ),
+            pytest.param(
+                {
+                    "rfsim_address": VALID_RFSIM_ADDRESS,
+                    "sst": "",
+                    "sd": VALID_SD,
+                },
+                id="empty_sst",
+            ),
+        ],
+    )
+    def test_given_invalid_remote_databag_when_get_rfsim_information_is_called_then_none_is_retrieved(  # noqa: E501
+        self, remote_data
+    ):
+        fiveg_rfsim_relation = testing.Relation(
+            endpoint="fiveg_rfsim",
+            interface="fiveg_rfsim",
+            remote_app_data=remote_data,
+        )
+        state_in = testing.State(
+            leader=True,
+            relations=[fiveg_rfsim_relation],
+        )
+        self.ctx.run(self.ctx.on.action("get-rfsim-information-invalid", params={}), state_in)
 
-        assert self.ctx.action_results
-        assert self.ctx.action_results == {"rfsim-address": "192.168.70.130"}
+    def test_given_rfsim_relation_does_not_exist_when_get_rfsim_information_then_none_is_retrieved(
+        self,
+    ):  # noqa: E501
+        state_in = testing.State(relations=[], leader=True)
+
+        self.ctx.run(self.ctx.on.action("get-rfsim-information-invalid", params={}), state_in)
+
+    def test_given_charm_is_not_leader_when_get_rfsim_information_then_none_is_retrieved(self):
+        state_in = testing.State(relations=[], leader=False)
+
+        self.ctx.run(self.ctx.on.action("get-rfsim-information-invalid", params={}), state_in)

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -387,7 +387,7 @@ class TestCharmConfigure(DUFixtures):
 
             self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
 
-            self.mock_rfsim_set_information.assert_called_once_with("1.2.3.4")
+            self.mock_rfsim_set_information.assert_called_once_with("1.2.3.4", 1, None)
 
     def test_given_f1_provider_information_is_no_available_when_pebble_ready_then_config_file_is_not_written(  # noqa: E501
         self,

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -11,7 +11,7 @@ from charms.oai_ran_cu_k8s.v0.fiveg_f1 import PLMNConfig, ProviderAppData
 from ops import testing
 from ops.pebble import Layer
 
-from tests.unit.fixtures import F1_PROVIDER_DATA, DUFixtures
+from tests.unit.fixtures import F1_PROVIDER_DATA, F1_PROVIDER_DATA_WITH_SD, DUFixtures
 
 F1_PROVIDER_DATA_MULTIPLE_PLMNS = ProviderAppData(
     f1_ip_address=IPv4Address("1.2.3.4"),
@@ -350,13 +350,52 @@ class TestCharmConfigure(DUFixtures):
 
             self.mock_f1_set_information.assert_called_once_with(port=2152)
 
-    def test_given_charm_is_configured_and_running_when_rfsim_relation_is_joined_then_rfsim_information_is_published(  # noqa: E501
+    def test_given_charm_is_configured_rfsim_address_is_not_available_and_f1_provider_data_is_available_when_rfsim_relation_is_joined_then_rfsim_information_is_not_published(  # noqa: E501
         self,
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
             self.mock_du_security_context.is_privileged.return_value = True
             self.mock_du_usb_volume.is_mounted.return_value = True
             self.mock_f1_get_remote_data.return_value = F1_PROVIDER_DATA
+            self.mock_check_output.return_value = None
+            f1_relation = testing.Relation(
+                endpoint="fiveg_f1",
+                interface="fiveg_f1",
+            )
+            rfsim_relation = testing.Relation(
+                endpoint="fiveg_rfsim",
+                interface="fiveg_rfsim",
+            )
+            config_mount = testing.Mount(
+                source=temp_dir,
+                location="/tmp/conf",
+            )
+            container = testing.Container(
+                name="du",
+                can_connect=True,
+                mounts={
+                    "config": config_mount,
+                },
+            )
+            state_in = testing.State(
+                leader=True,
+                relations=[f1_relation, rfsim_relation],
+                containers=[container],
+                model=testing.Model(name="whatever"),
+                config={"simulation-mode": True},
+            )
+
+            self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
+
+            self.mock_rfsim_set_information.assert_not_called()
+
+    def test_given_charm_is_configured_running_and_f1_provider_data_is_not_available_when_rfsim_relation_is_joined_then_rfsim_information_is_not_published(  # noqa: E501
+        self,
+    ):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self.mock_du_security_context.is_privileged.return_value = True
+            self.mock_du_usb_volume.is_mounted.return_value = True
+            self.mock_f1_get_remote_data.return_value = None
             self.mock_check_output.return_value = b"1.2.3.4"
             f1_relation = testing.Relation(
                 endpoint="fiveg_f1",
@@ -387,7 +426,119 @@ class TestCharmConfigure(DUFixtures):
 
             self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
 
-            self.mock_rfsim_set_information.assert_called_once_with("1.2.3.4", 1, None)
+            self.mock_rfsim_set_information.assert_not_called()
+
+    def test_given_charm_is_configured_running_and_f1_provider_data_includes_multiple_plmns_when_rfsim_relation_is_joined_then_rfsim_information_is_published_with_first_plmn_info(  # noqa: E501
+        self,
+    ):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self.mock_du_security_context.is_privileged.return_value = True
+            self.mock_du_usb_volume.is_mounted.return_value = True
+            self.mock_f1_get_remote_data.return_value = F1_PROVIDER_DATA_MULTIPLE_PLMNS
+            self.mock_check_output.return_value = b"1.2.3.4"
+            f1_relation = testing.Relation(
+                endpoint="fiveg_f1",
+                interface="fiveg_f1",
+            )
+            rfsim_relation = testing.Relation(
+                endpoint="fiveg_rfsim",
+                interface="fiveg_rfsim",
+            )
+            config_mount = testing.Mount(
+                source=temp_dir,
+                location="/tmp/conf",
+            )
+            container = testing.Container(
+                name="du",
+                can_connect=True,
+                mounts={
+                    "config": config_mount,
+                },
+            )
+            state_in = testing.State(
+                leader=True,
+                relations=[f1_relation, rfsim_relation],
+                containers=[container],
+                model=testing.Model(name="whatever"),
+                config={"simulation-mode": True},
+            )
+
+            self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
+
+            self.mock_rfsim_set_information.assert_called_once_with("1.2.3.4", 12, None)
+
+    def test_given_charm_is_configured_running_and_f1_relation_is_not_created_when_rfsim_relation_is_joined_then_rfsim_information_is_not_published(  # noqa: E501
+        self,
+    ):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self.mock_du_security_context.is_privileged.return_value = True
+            self.mock_du_usb_volume.is_mounted.return_value = True
+            self.mock_check_output.return_value = b"1.2.3.4"
+            rfsim_relation = testing.Relation(
+                endpoint="fiveg_rfsim",
+                interface="fiveg_rfsim",
+            )
+            config_mount = testing.Mount(
+                source=temp_dir,
+                location="/tmp/conf",
+            )
+            container = testing.Container(
+                name="du",
+                can_connect=True,
+                mounts={
+                    "config": config_mount,
+                },
+            )
+            state_in = testing.State(
+                leader=True,
+                relations=[rfsim_relation],
+                containers=[container],
+                model=testing.Model(name="whatever"),
+                config={"simulation-mode": True},
+            )
+
+            self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
+
+            self.mock_rfsim_set_information.assert_not_called()
+
+    def test_given_charm_is_configured_running_and_f1_provider_data_is_available_with_sd_when_rfsim_relation_is_joined_then_rfsim_information_is_published_including_sd(  # noqa: E501
+        self,
+    ):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self.mock_du_security_context.is_privileged.return_value = True
+            self.mock_du_usb_volume.is_mounted.return_value = True
+            self.mock_f1_get_remote_data.return_value = F1_PROVIDER_DATA_WITH_SD
+            self.mock_check_output.return_value = b"1.2.3.4"
+            f1_relation = testing.Relation(
+                endpoint="fiveg_f1",
+                interface="fiveg_f1",
+            )
+            rfsim_relation = testing.Relation(
+                endpoint="fiveg_rfsim",
+                interface="fiveg_rfsim",
+            )
+            config_mount = testing.Mount(
+                source=temp_dir,
+                location="/tmp/conf",
+            )
+            container = testing.Container(
+                name="du",
+                can_connect=True,
+                mounts={
+                    "config": config_mount,
+                },
+            )
+            state_in = testing.State(
+                leader=True,
+                relations=[f1_relation, rfsim_relation],
+                containers=[container],
+                model=testing.Model(name="whatever"),
+                config={"simulation-mode": True},
+            )
+
+            self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
+
+            self.mock_rfsim_set_information.assert_called_once_with("1.2.3.4", 1, 1)
 
     def test_given_f1_provider_information_is_no_available_when_pebble_ready_then_config_file_is_not_written(  # noqa: E501
         self,

--- a/tests/unit/test_charm_fiveg_rfsim_relation_changed.py
+++ b/tests/unit/test_charm_fiveg_rfsim_relation_changed.py
@@ -10,8 +10,8 @@ from ops.pebble import Layer, ServiceStatus
 from tests.unit.fixtures import F1_PROVIDER_DATA_WITH_SD, DUFixtures
 
 
-class TestCharmFivegRFSIMRelationJoined(DUFixtures):
-    def test_given_f1_relation_exists_service_not_running_when_fiveg_rfsim_relation_joined_then_rfsim_information_is_not_in_relation_databag(  # noqa: E501
+class TestCharmFivegRFSIMRelationChanged(DUFixtures):
+    def test_given_f1_relation_exists_service_not_running_when_fiveg_rfsim_relation_chaned_then_rfsim_information_is_not_in_relation_databag(  # noqa: E501
         self,
     ):
         f1_relation = testing.Relation(endpoint="fiveg_f1", interface="fiveg_f1")
@@ -24,12 +24,12 @@ class TestCharmFivegRFSIMRelationJoined(DUFixtures):
         )
         self.mock_check_output.return_value = b"1.2.3.4"
 
-        state_out = self.ctx.run(self.ctx.on.relation_joined(fiveg_rfsim_relation), state_in)
+        state_out = self.ctx.run(self.ctx.on.relation_changed(fiveg_rfsim_relation), state_in)
 
         relation = state_out.get_relation(fiveg_rfsim_relation.id)
         assert relation.local_app_data == {}
 
-    def test_given_given_service_is_running_and_f1_relation_joined_and_remote_network_information_exists_when_fiveg_rfsim_relation_joined_then_rfsim_information_is_in_relation_databag(  # noqa: E501
+    def test_given_given_service_is_running_and_f1_relation_joined_and_remote_network_information_exists_when_fiveg_rfsim_relation_changed_then_rfsim_information_is_in_relation_databag(  # noqa: E501
         self,
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -80,11 +80,11 @@ class TestCharmFivegRFSIMRelationJoined(DUFixtures):
                 config={"simulation-mode": True},
             )
 
-            state_out = self.ctx.run(self.ctx.on.relation_joined(fiveg_rfsim_relation), state_in)
+            state_out = self.ctx.run(self.ctx.on.relation_changed(fiveg_rfsim_relation), state_in)
             relation = state_out.get_relation(fiveg_rfsim_relation.id)
             assert relation.local_app_data == {"rfsim_address": "1.2.3.4", "sst": "1", "sd": "1"}
 
-    def test_given_given_service_is_running_and_f1_relation_does_not_exist_when_fiveg_rfsim_relation_joined_then_rfsim_information_is_not_in_relation_databag(  # noqa: E501
+    def test_given_given_service_is_running_and_f1_relation_does_not_exist_when_fiveg_rfsim_relation_changed_then_rfsim_information_is_not_in_relation_databag(  # noqa: E501
         self,
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -128,6 +128,6 @@ class TestCharmFivegRFSIMRelationJoined(DUFixtures):
                 config={"simulation-mode": True},
             )
 
-            state_out = self.ctx.run(self.ctx.on.relation_joined(fiveg_rfsim_relation), state_in)
+            state_out = self.ctx.run(self.ctx.on.relation_changed(fiveg_rfsim_relation), state_in)
             relation = state_out.get_relation(fiveg_rfsim_relation.id)
             assert relation.local_app_data == {}

--- a/tests/unit/test_charm_fiveg_rfsim_relation_changed.py
+++ b/tests/unit/test_charm_fiveg_rfsim_relation_changed.py
@@ -11,7 +11,7 @@ from tests.unit.fixtures import F1_PROVIDER_DATA_WITH_SD, DUFixtures
 
 
 class TestCharmFivegRFSIMRelationChanged(DUFixtures):
-    def test_given_f1_relation_exists_service_not_running_when_fiveg_rfsim_relation_chaned_then_rfsim_information_is_not_in_relation_databag(  # noqa: E501
+    def test_given_f1_relation_exists_service_not_running_when_fiveg_rfsim_relation_changed_then_rfsim_information_is_not_in_relation_databag(  # noqa: E501
         self,
     ):
         f1_relation = testing.Relation(endpoint="fiveg_f1", interface="fiveg_f1")

--- a/tests/unit/test_charm_fiveg_rfsim_relation_joined.py
+++ b/tests/unit/test_charm_fiveg_rfsim_relation_joined.py
@@ -7,19 +7,20 @@ import tempfile
 from ops import testing
 from ops.pebble import Layer, ServiceStatus
 
-from tests.unit.fixtures import F1_PROVIDER_DATA, DUFixtures
+from tests.unit.fixtures import F1_PROVIDER_DATA_WITH_SD, DUFixtures
 
 
 class TestCharmFivegRFSIMRelationJoined(DUFixtures):
-    def test_given_service_not_running_when_fiveg_rfsim_relation_joined_then_rfsim_information_is_not_in_relation_databag(  # noqa: E501
+    def test_given_f1_relation_exists_service_not_running_when_fiveg_rfsim_relation_joined_then_rfsim_information_is_not_in_relation_databag(  # noqa: E501
         self,
     ):
+        f1_relation = testing.Relation(endpoint="fiveg_f1", interface="fiveg_f1")
         fiveg_rfsim_relation = testing.Relation(endpoint="fiveg_rfsim", interface="fiveg_rfsim")
         container = testing.Container(name="du", can_connect=True)
         state_in = testing.State(
             leader=True,
             containers=[container],
-            relations=[fiveg_rfsim_relation],
+            relations=[fiveg_rfsim_relation, f1_relation],
         )
         self.mock_check_output.return_value = b"1.2.3.4"
 
@@ -28,13 +29,13 @@ class TestCharmFivegRFSIMRelationJoined(DUFixtures):
         relation = state_out.get_relation(fiveg_rfsim_relation.id)
         assert relation.local_app_data == {}
 
-    def test_given_given_service_is_running_when_fiveg_rfsim_relation_joined_then_rfsim_information_is_in_relation_databag(  # noqa: E501
+    def test_given_given_service_is_running_and_f1_relation_joined_and_remote_network_information_exists_when_fiveg_rfsim_relation_joined_then_rfsim_information_is_in_relation_databag(  # noqa: E501
         self,
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
             self.mock_du_security_context.is_privileged.return_value = True
             self.mock_du_usb_volume.is_mounted.return_value = True
-            self.mock_f1_get_remote_data.return_value = F1_PROVIDER_DATA
+            self.mock_f1_get_remote_data.return_value = F1_PROVIDER_DATA_WITH_SD
             self.mock_check_output.return_value = b"1.2.3.4"
             f1_relation = testing.Relation(
                 endpoint="fiveg_f1",
@@ -43,7 +44,7 @@ class TestCharmFivegRFSIMRelationJoined(DUFixtures):
             fiveg_rfsim_relation = testing.Relation(
                 endpoint="fiveg_rfsim",
                 interface="fiveg_rfsim",
-                local_app_data={"rfsim_address": "1.2.3.4"},
+                local_app_data={"rfsim_address": "1.2.3.4", "sst": "1", "sd": "1"},
             )
             config_mount = testing.Mount(
                 source=temp_dir,
@@ -78,9 +79,55 @@ class TestCharmFivegRFSIMRelationJoined(DUFixtures):
                 model=testing.Model(name="whatever"),
                 config={"simulation-mode": True},
             )
-            self.mock_rfsim_set_information.return_value = "1.2.3.4"
 
             state_out = self.ctx.run(self.ctx.on.relation_joined(fiveg_rfsim_relation), state_in)
-
             relation = state_out.get_relation(fiveg_rfsim_relation.id)
-            assert relation.local_app_data == {"rfsim_address": "1.2.3.4"}
+            assert relation.local_app_data == {"rfsim_address": "1.2.3.4", "sst": "1", "sd": "1"}
+
+    def test_given_given_service_is_running_and_f1_relation_does_not_exist_when_fiveg_rfsim_relation_joined_then_rfsim_information_is_not_in_relation_databag(  # noqa: E501
+        self,
+    ):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self.mock_du_security_context.is_privileged.return_value = True
+            self.mock_check_output.return_value = b"1.2.3.4"
+            fiveg_rfsim_relation = testing.Relation(
+                endpoint="fiveg_rfsim",
+                interface="fiveg_rfsim",
+            )
+            config_mount = testing.Mount(
+                source=temp_dir,
+                location="/tmp/conf",
+            )
+            container = testing.Container(
+                name="du",
+                can_connect=True,
+                layers={
+                    "du": Layer(
+                        {
+                            "services": {
+                                "du": {
+                                    "startup": "enabled",
+                                    "override": "replace",
+                                    "command": "/opt/oai-gnb/bin/nr-softmodem -O /tmp/conf/du.conf -E --sa ",  # noqa: E501
+                                    "environment": {"TZ": "UTC"},
+                                }
+                            }
+                        }
+                    )
+                },
+                service_statuses={"du": ServiceStatus.ACTIVE},
+                mounts={
+                    "config": config_mount,
+                },
+            )
+            state_in = testing.State(
+                leader=True,
+                relations=[fiveg_rfsim_relation],
+                containers=[container],
+                model=testing.Model(name="whatever"),
+                config={"simulation-mode": True},
+            )
+
+            state_out = self.ctx.run(self.ctx.on.relation_joined(fiveg_rfsim_relation), state_in)
+            relation = state_out.get_relation(fiveg_rfsim_relation.id)
+            assert relation.local_app_data == {}


### PR DESCRIPTION
# Description

This PR extends the fiveg_rfsim interface according to https://github.com/canonical/charm-relation-interfaces/pull/202 by putting RFSIM address, SST and SD information to the relation data bag.


- Validates Provider application data before putting the information to the relation data bag
- Removes custom events and only uses standart charm events (relation joined, relation changed) to simplify the implementation
- Expand unit tests for fiveg_rfsim interface


# Dependencies

The implementation in the charm depends on fiveg_f1 interface as this interface is used to get the SST and SD data from CU charm. fiveg_rfsim relation should wait until data is  retrieved through fiveg_f1 relation. https://github.com/canonical/oai-ran-du-k8s-operator/pull/58 should be merged.


# Note
fiveg_f1 interface can carry multiple PLMNs and each PLMN includes SST and SD.
Which SST and SD value should be sent to UE in the fiveg_rfsim relation data ? 
After discussing this with @Gmerold , TE126 updated to use the first PLMN. 
Fiveg_rfsim interface only used with UE simulator. 
For real UE's, device group of slice includes the IMSI which can be associated with the related UE. 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library