### PR TITLE
feat: extend f1 interface integration test

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -86,7 +86,6 @@ class OAIRANDUOperator(CharmBase):
         self.framework.observe(self.on.update_status, self._configure)
         self.framework.observe(self.on.config_changed, self._configure)
         self.framework.observe(self.on.du_pebble_ready, self._configure)
-        self.framework.observe(self.on[F1_RELATION_NAME].relation_created, self._configure)
         self.framework.observe(self.on[F1_RELATION_NAME].relation_changed, self._configure)
         self.framework.observe(self.on[RFSIM_RELATION_NAME].relation_changed, self._configure)
         self.framework.observe(self.on.remove, self._on_remove)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -2,25 +2,27 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import json
+import textwrap
 from pathlib import Path
 
 import pytest
+import requests
 import yaml
 from pytest_operator.plugin import OpsTest
 
 METADATA = yaml.safe_load(Path("./charmcraft.yaml").read_text())
 APP_NAME = METADATA["name"]
 AMF_CHARM_NAME = "sdcore-amf-k8s"
-AMF_CHARM_CHANNEL = "1.5/edge"
+AMF_CHARM_CHANNEL = "1.6/edge"
 DB_CHARM_NAME = "mongodb-k8s"
 DB_CHARM_CHANNEL = "6/stable"
 GRAFANA_AGENT_CHARM_NAME = "grafana-agent-k8s"
 NRF_CHARM_NAME = "sdcore-nrf-k8s"
-NRF_CHARM_CHANNEL = "1.5/edge"
+NRF_CHARM_CHANNEL = "1.6/edge"
 CU_CHARM_NAME = "oai-ran-cu-k8s"
 CU_CHARM_CHANNEL = "2.1/edge"
-NMS_CHARM_NAME = "sdcore-nms-k8s"
-NMS_CHARM_CHANNEL = "1.5/edge"
+NMS_MOCK = "nms-mock"
 TLS_CHARM_NAME = "self-signed-certificates"
 TLS_CHARM_CHANNEL = "latest/stable"
 TIMEOUT = 5 * 60
@@ -99,7 +101,7 @@ async def deploy_dependencies(ops_test: OpsTest):
     assert ops_test.model
     await _deploy_mongodb(ops_test)
     await _deploy_tls_provider(ops_test)
-    await _deploy_webui(ops_test)
+    await _deploy_nms_mock(ops_test)
     await _deploy_nrf(ops_test)
     await _deploy_amf(ops_test)
     await _deploy_grafana_agent(ops_test)
@@ -115,7 +117,7 @@ async def _deploy_amf(ops_test: OpsTest):
         trust=True,
     )
     await ops_test.model.integrate(relation1=AMF_CHARM_NAME, relation2=NRF_CHARM_NAME)
-    await ops_test.model.integrate(relation1=AMF_CHARM_NAME, relation2=NMS_CHARM_NAME)
+    await ops_test.model.integrate(relation1=f"{AMF_CHARM_NAME}:sdcore_config", relation2=NMS_MOCK)
     await ops_test.model.integrate(relation1=AMF_CHARM_NAME, relation2=TLS_CHARM_NAME)
 
 
@@ -157,26 +159,71 @@ async def _deploy_nrf(ops_test: OpsTest):
     )
     await ops_test.model.integrate(relation1=NRF_CHARM_NAME, relation2=DB_CHARM_NAME)
     await ops_test.model.integrate(relation1=NRF_CHARM_NAME, relation2=TLS_CHARM_NAME)
-    await ops_test.model.integrate(relation1=NRF_CHARM_NAME, relation2=NMS_CHARM_NAME)
+    await ops_test.model.integrate(relation1=f"{NRF_CHARM_NAME}:sdcore_config", relation2=NMS_MOCK)
 
 
-async def _deploy_webui(ops_test: OpsTest):
+async def _deploy_nms_mock(ops_test: OpsTest):
+    fiveg_core_gnb_lib_url = "https://github.com/canonical/sdcore-nms-k8s-operator/raw/main/lib/charms/sdcore_nms_k8s/v0/fiveg_core_gnb.py"
+    fiveg_core_gnb_lib = requests.get(fiveg_core_gnb_lib_url, timeout=10).text
+    sdcore_config_lib_url = "https://github.com/canonical/sdcore-nms-k8s-operator/raw/main/lib/charms/sdcore_nms_k8s/v0/sdcore_config.py"
+    sdcore_config_lib = requests.get(sdcore_config_lib_url, timeout=10).text
+    any_charm_src_overwrite = {
+        "fiveg_core_gnb.py": fiveg_core_gnb_lib,
+        "sdcore_config.py": sdcore_config_lib,
+        "any_charm.py": textwrap.dedent(
+            """\
+        from fiveg_core_gnb import FivegCoreGnbProvides, PLMNConfig
+        from sdcore_config import SdcoreConfigProvides
+        from any_charm_base import AnyCharmBase
+        from ops.framework import EventBase
+        SDCORE_CONFIG_RELATION_NAME = "provide-sdcore-config"
+        CORE_GNB_RELATION_NAME = "provide-fiveg-core-gnb"
+
+        class AnyCharm(AnyCharmBase):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self._sdcore_config = SdcoreConfigProvides(self, SDCORE_CONFIG_RELATION_NAME)
+                self._fiveg_core_gnb_provider = FivegCoreGnbProvides(self, CORE_GNB_RELATION_NAME)
+                self.framework.observe(
+                    self.on[SDCORE_CONFIG_RELATION_NAME].relation_changed,
+                    self.sdcore_config_relation_changed,
+                )
+                self.framework.observe(
+                    self.on[CORE_GNB_RELATION_NAME].relation_changed,
+                    self.fiveg_core_gnb_relation_changed,
+                )
+
+            def sdcore_config_relation_changed(self, event: EventBase) -> None:
+                sdcore_config_relations = self.model.relations.get(SDCORE_CONFIG_RELATION_NAME)
+                if not sdcore_config_relations:
+                    logger.info("No %s relations found.", SDCORE_CONFIG_RELATION_NAME)
+                    return
+                self._sdcore_config.set_webui_url_in_all_relations(webui_url="sdcore-nms:9876")
+
+            def fiveg_core_gnb_relation_changed(self, event: EventBase):
+                core_gnb_relations = self.model.relations.get(CORE_GNB_RELATION_NAME)
+                if not core_gnb_relations:
+                    logger.info("No %s relations found.", CORE_GNB_RELATION_NAME)
+                    return
+                for relation in core_gnb_relations:
+                    self._fiveg_core_gnb_provider.publish_gnb_config_information(
+                        relation_id=relation.id,
+                        tac=1,
+                        plmns=[PLMNConfig(mcc="001", mnc="01", sst=1, sd=1056816)],
+                    )
+        """
+        ),
+    }
     assert ops_test.model
     await ops_test.model.deploy(
-        NMS_CHARM_NAME,
-        application_name=NMS_CHARM_NAME,
-        channel=NMS_CHARM_CHANNEL,
+        "any-charm",
+        application_name=NMS_MOCK,
+        channel="beta",
+        config={
+            "src-overwrite": json.dumps(any_charm_src_overwrite),
+            "python-packages": "pytest-interface-tester",
+        },
     )
-    await ops_test.model.integrate(
-        relation1=f"{NMS_CHARM_NAME}:common_database", relation2=f"{DB_CHARM_NAME}"
-    )
-    await ops_test.model.integrate(
-        relation1=f"{NMS_CHARM_NAME}:auth_database", relation2=f"{DB_CHARM_NAME}"
-    )
-    await ops_test.model.integrate(
-        relation1=f"{NMS_CHARM_NAME}:webui_database", relation2=DB_CHARM_NAME
-    )
-    await ops_test.model.integrate(relation1=NMS_CHARM_NAME, relation2=TLS_CHARM_NAME)
 
 
 async def _deploy_cu(ops_test: OpsTest):
@@ -188,3 +235,4 @@ async def _deploy_cu(ops_test: OpsTest):
         trust=True,
     )
     await ops_test.model.integrate(relation1=CU_CHARM_NAME, relation2=AMF_CHARM_NAME)
+    await ops_test.model.integrate(relation1=f"{CU_CHARM_NAME}:fiveg_core_gnb", relation2=NMS_MOCK)


### PR DESCRIPTION
# Description

- The integration test is simplified to avoid dependecies with the NMS. `any_charm` (A charm simulates any kind of relation consumer charm to make it easy to write integration tests for relation provider charms) is used.
- `any_charm` mocks the NMS so it implements the  `sdcore_config` and `fiveg_core_gnb` in the integration tests.
- The `sdcore_config` and `fiveg_core_gnb` relations were added to `any_charm` [here](https://github.com/canonical/any-charm/pull/31)

- Since a `relation_changed` event is triggered just after `relation_created` event, we can just observe the former.


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library