### PR TITLE
feat: expose three quarter sampling rate option

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -75,8 +75,7 @@ config:
       type: boolean
       default: false
       description: |
-        This parameter enables three-quarter sampling on DU by adding -E flag to DU startup command. 
-        This flag might be required to split 8 sample rate to run DU connected to physical devices (such as USRP B210).
+        This parameter enables three-quarter sampling on DU by adding -E flag to DU startup command. This flag might be required to split 8 sample rate to run DU connected to physical devices (such as USRP B210).
 
 parts:
   charm:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -71,6 +71,12 @@ config:
       description: |
         Run DU in simulation mode.
         In the simulation mode, the DU emulates the Radio Unit (RU) which, in real deployment, would have been a physical device connected to the DU. Simulation mode has been designed to work with the OAI RAN NR UE (a simulated 5G User Equipment).
+    use-three-quarter-sampling:
+      type: boolean
+      default: false
+      description: |
+        This parameter enables three-quarter sampling on DU by adding -E flag to DU startup command. 
+        This flag might be required to split 8 sample rate to run DU connected to physical devices (such as USRP B210).
 
 parts:
   charm:

--- a/src/charm.py
+++ b/src/charm.py
@@ -420,9 +420,13 @@ class OAIRANDUOperator(CharmBase):
     @property
     def _du_startup_command(self) -> str:
         rfsim_switch = ""
+        three_quarter_sampling = ""
+        if self._charm_config.use_three_quarter_sampling:
+            three_quarter_sampling = "-E "
         if self._charm_config.simulation_mode:
             rfsim_switch = "--rfsim"
-        return f"/opt/oai-gnb/bin/nr-softmodem -O {BASE_CONFIG_PATH}/{CONFIG_FILE_NAME} --continuous-tx {rfsim_switch}"  # noqa: E501
+
+        return f"/opt/oai-gnb/bin/nr-softmodem -O {BASE_CONFIG_PATH}/{CONFIG_FILE_NAME} {three_quarter_sampling}--continuous-tx {rfsim_switch}"  # noqa: E501
 
     @property
     def _du_environment_variables(self) -> dict:

--- a/src/charm_config.py
+++ b/src/charm_config.py
@@ -59,6 +59,7 @@ class DUConfig(BaseModel):  # pylint: disable=too-few-public-methods
     f1_ip_address: str = Field(default="192.168.254.5/24")
     f1_port: int = Field(ge=1, le=65535)
     simulation_mode: bool = False
+    use_three_quarter_sampling: bool = False
 
     @field_validator("f1_ip_address", mode="before")
     @classmethod
@@ -78,6 +79,7 @@ class CharmConfig:
         f1_ip_address: IP address used by f1 interface
         f1_port: Number of the port used for F1 traffic
         simulation_mode: Run DU in simulation mode
+        use_three_quarter_sampling: Run DU with three-quarter sampling rate
     """
 
     cni_type: CNIType
@@ -85,6 +87,7 @@ class CharmConfig:
     f1_ip_address: str
     f1_port: int
     simulation_mode: bool
+    use_three_quarter_sampling: bool
 
     def __init__(self, *, du_config: DUConfig):
         """Initialize a new instance of the CharmConfig class.
@@ -97,6 +100,7 @@ class CharmConfig:
         self.f1_ip_address = du_config.f1_ip_address
         self.f1_port = du_config.f1_port
         self.simulation_mode = du_config.simulation_mode
+        self.use_three_quarter_sampling = du_config.use_three_quarter_sampling
 
     @classmethod
     def from_charm(

--- a/tests/unit/test_charm_fiveg_rfsim_relation_changed.py
+++ b/tests/unit/test_charm_fiveg_rfsim_relation_changed.py
@@ -60,7 +60,7 @@ class TestCharmFivegRFSIMRelationChanged(DUFixtures):
                                 "du": {
                                     "startup": "enabled",
                                     "override": "replace",
-                                    "command": "/opt/oai-gnb/bin/nr-softmodem -O /tmp/conf/du.conf -E --sa ",  # noqa: E501
+                                    "command": "/opt/oai-gnb/bin/nr-softmodem -O /tmp/conf/du.conf --continuous-tx ",  # noqa: E501
                                     "environment": {"TZ": "UTC"},
                                 }
                             }
@@ -108,7 +108,7 @@ class TestCharmFivegRFSIMRelationChanged(DUFixtures):
                                 "du": {
                                     "startup": "enabled",
                                     "override": "replace",
-                                    "command": "/opt/oai-gnb/bin/nr-softmodem -O /tmp/conf/du.conf -E --sa ",  # noqa: E501
+                                    "command": "/opt/oai-gnb/bin/nr-softmodem -O /tmp/conf/du.conf --continuous-tx ",  # noqa: E501
                                     "environment": {"TZ": "UTC"},
                                 }
                             }


### PR DESCRIPTION
# Description

This PR exposes `three-quarter sampling` which is a DU startup command option.
The command line option -E can be used to enable three-quarter sampling for split 8 sample rate. This option might be required for certain radios (e.g., 40MHz with B210).

# Usage

Enable three-quarter sampling on a running DU:
```
juju config du use-three-quarter-sampling=true
````

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library