### PR TITLE
fix: fiveg_rfsim lib

### DIFF
--- a/lib/charms/oai_ran_du_k8s/v0/fiveg_rfsim.py
+++ b/lib/charms/oai_ran_du_k8s/v0/fiveg_rfsim.py
@@ -115,7 +115,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 4
 
 
 logger = logging.getLogger(__name__)

--- a/lib/charms/oai_ran_du_k8s/v0/fiveg_rfsim.py
+++ b/lib/charms/oai_ran_du_k8s/v0/fiveg_rfsim.py
@@ -292,15 +292,23 @@ class RFSIMRequires(Object):
             logger.warning("No remote application in relation: %s", self.relation_name)
             return None
         remote_app_relation_data: Dict[str, Any] = dict(relation.data[relation.app])
+
         try:
-            remote_app_relation_data["sd"] = int(remote_app_relation_data.get("sd", ""))
             remote_app_relation_data["sst"] = int(remote_app_relation_data.get("sst", ""))
-        except ValueError:
-            logger.error("Invalid relation data: %s", remote_app_relation_data)
+        except ValueError as err:
+            logger.error("Invalid relation data: %s: %s", remote_app_relation_data, str(err))
             return None
+
+        try:
+            if sd := remote_app_relation_data.get("sd"):
+                remote_app_relation_data["sd"] = int(sd)
+        except ValueError as err:
+            logger.error("Invalid relation data: %s: %s", remote_app_relation_data, str(err))
+            return None
+
         try:
             provider_app_data = ProviderAppData(**remote_app_relation_data)
-        except ValidationError:
-            logger.error("Invalid relation data: %s", remote_app_relation_data)
+        except ValidationError as err:
+            logger.error("Invalid relation data: %s: %s", remote_app_relation_data, str(err))
             return None
         return provider_app_data

--- a/tests/unit/lib/charms/oai_ran_du/v0/test_charms/test_requirer_charm/src/charm.py
+++ b/tests/unit/lib/charms/oai_ran_du/v0/test_charms/test_requirer_charm/src/charm.py
@@ -29,8 +29,9 @@ class DummyFivegRFSIMRequires(CharmBase):
         data = {
             "rfsim_address": rfsim_address,
             "sst": int(sst),
-            "sd": int(sd),
         }
+        if sd:
+            data["sd"] = int(sd)
         provider_app_data = ProviderAppData(**data)
         assert provider_app_data == self.rfsim_requirer.get_provider_rfsim_information()
 

--- a/tests/unit/lib/charms/oai_ran_du/v0/test_fiveg_rfsim_requirer_interface.py
+++ b/tests/unit/lib/charms/oai_ran_du/v0/test_fiveg_rfsim_requirer_interface.py
@@ -35,26 +35,48 @@ class TestFivegRFSIMRequires:
             },
         )
 
-    def test_given_rfsim_information_in_relation_data_when_get_rfsim_information_is_called_then_information_is_returned(  # noqa: E501
-        self,
+    @pytest.mark.parametrize(
+        "remote_data,expected_rfsim_address,expected_sst,expected_sd",
+        [
+            pytest.param(
+                {
+                    "rfsim_address": VALID_RFSIM_ADDRESS,
+                    "sst": VALID_SST,
+                    "sd": VALID_SD,
+                },
+                VALID_RFSIM_ADDRESS,
+                int(VALID_SST),
+                int(VALID_SD),
+                id="all_attributes_are_available",
+            ),
+            pytest.param(
+                {
+                    "rfsim_address": VALID_RFSIM_ADDRESS,
+                    "sst": VALID_SST,
+                },
+                VALID_RFSIM_ADDRESS,
+                int(VALID_SST),
+                int(),
+                id="empty_sd",
+            ),
+        ],
+    )
+    def test_given_valid_rfsim_information_in_relation_data_when_get_rfsim_information_is_called_then_information_is_returned(  # noqa: E501
+        self, remote_data, expected_rfsim_address, expected_sst, expected_sd
     ):
         fiveg_rfsim_relation = testing.Relation(
             endpoint="fiveg_rfsim",
             interface="fiveg_rfsim",
-            remote_app_data={
-                "rfsim_address": VALID_RFSIM_ADDRESS,
-                "sst": VALID_SST,
-                "sd": VALID_SD,
-            },
+            remote_app_data=remote_data,
         )
         state_in = testing.State(
             leader=True,
             relations=[fiveg_rfsim_relation],
         )
         params = {
-            "expected_rfsim_address": VALID_RFSIM_ADDRESS,
-            "expected_sst": int(VALID_SST),
-            "expected_sd": int(VALID_SD),
+            "expected_rfsim_address": expected_rfsim_address,
+            "expected_sst": expected_sst,
+            "expected_sd": expected_sd,
         }
         self.ctx.run(self.ctx.on.action("get-rfsim-information", params=params), state_in)
 


### PR DESCRIPTION
# Description

This PR is fixing get_provider_rfsim_information method which is failing if `SD` is not available.

- Get SD optionally
-  Log error messages
- Improve fiveg_rfsim interface requirer tests


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library