### PR TITLE
fix: scenario.runtime import error in nms-mock charm

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -179,7 +179,7 @@ async def _deploy_nms_mock(ops_test: OpsTest):
         channel="beta",
         config={
             "src-overwrite": json.dumps(any_charm_src_overwrite),
-            "python-packages": "ops-scenario==7.0.5\nops==2.17.1\npytest-interface-tester",
+            "python-packages": "ops==2.17.1\npytest-interface-tester",
         },
     )
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -179,7 +179,7 @@ async def _deploy_nms_mock(ops_test: OpsTest):
         channel="beta",
         config={
             "src-overwrite": json.dumps(any_charm_src_overwrite),
-            "python-packages": "pytest-interface-tester",
+            "python-packages": "ops-scenario==7.0.5\nops==2.17.1\npytest-interface-tester",
         },
     )
 


### PR DESCRIPTION
# Description
nms-mock charm install hook is failing to find `scenario.runtime` which is imported from `ops`. 
This causes failure in integration tests.
The `scenario.runtime`library relies on `ops==2.17.x`.
Latest version of `ops` has breaking changes that make this library incompatible.

As a workaround we need to pin the ops version until incompatibilities are solved in the dependent projects.

Logs that indicate the import issue in the juju debug logs:
```
unit-nms-mock-0: 11:38:56 WARNING unit.nms-mock/0.install   File "/var/lib/juju/agents/unit-nms-mock-0/charm/venv/ops/testing.py", line 181, in <module>
unit-nms-mock-0: 11:38:56 WARNING unit.nms-mock/0.install     import scenario.runtime as _runtime
unit-nms-mock-0: 11:38:56 WARNING unit.nms-mock/0.install ModuleNotFoundError: No module named 'scenario.runtime'
```

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library