### PR TITLE
feat: calculate DL AbsoluteFrequencyPointA

### DIFF
--- a/src/du_parameters/dl_absolute_freq_point_a.py
+++ b/src/du_parameters/dl_absolute_freq_point_a.py
@@ -40,14 +40,22 @@ def get_dl_absolute_frequency_point_a(center_freq: Frequency, bandwidth: Frequen
     try:
         lowest_freq = center_freq - (bandwidth / CONFIG_CONSTANT_TWO)
         arfcn = ARFCN.from_frequency(lowest_freq)
+        logger.info("Calculated downlink absolute frequency Point A: %s", arfcn)
         return arfcn
     except (
-            TypeError,
-            ValueError,
-            decimal.InvalidOperation,
-            NotImplementedError,
-            GetRangeFromFrequencyError,
+        TypeError,
+        ValueError,
+        decimal.InvalidOperation,
+        NotImplementedError,
+        GetRangeFromFrequencyError,
     ) as e:
+        logger.error(
+            "Error calculating downlink absolute frequency Point A"
+            " using center_freq=%s and bandwidth=%s: %s",
+            center_freq,
+            bandwidth,
+            str(e),
+        )
         raise DLAbsoluteFrequencyPointAError(
             f"Error calculating downlink absolute frequency Point A "
             f"using center_freq={center_freq} and bandwidth={bandwidth}: {e}"

--- a/src/du_parameters/dl_absolute_freq_point_a.py
+++ b/src/du_parameters/dl_absolute_freq_point_a.py
@@ -1,0 +1,54 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Calculate the frequency location of Point A in the downlink."""
+
+import decimal
+import logging
+from decimal import Decimal
+
+from src.du_parameters.frequency import (
+    ARFCN,
+    Frequency,
+    GetRangeFromFrequencyError,
+)
+
+logger = logging.getLogger(__name__)
+
+CONFIG_CONSTANT_TWO = Decimal("2")
+
+
+class DLAbsoluteFrequencyPointAError(Exception):
+    """Exception raised when Downlink Absolute Frequency Point A calculation fails."""
+
+    pass
+
+
+def get_dl_absolute_frequency_point_a(center_freq: Frequency, bandwidth: Frequency) -> ARFCN:
+    """Calculate downlink absolute frequency Point A using center frequency and bandwidth.
+
+    Args:
+        center_freq (Frequency): Center frequency
+        bandwidth (Frequency): Bandwidth
+
+    Returns:
+        ARFCN: The dl absolute frequency point A in ARFCN format
+
+    Raises:
+        DLAbsoluteFrequencyPointAError: If calculation fails due to invalid inputs or operations
+    """
+    try:
+        lowest_freq = center_freq - (bandwidth / CONFIG_CONSTANT_TWO)
+        arfcn = ARFCN.from_frequency(lowest_freq)
+        return arfcn
+    except (
+            TypeError,
+            ValueError,
+            decimal.InvalidOperation,
+            NotImplementedError,
+            GetRangeFromFrequencyError,
+    ) as e:
+        raise DLAbsoluteFrequencyPointAError(
+            f"Error calculating downlink absolute frequency Point A "
+            f"using center_freq={center_freq} and bandwidth={bandwidth}: {e}"
+        )

--- a/tests/integration/test_absolute_freq_point_a.py
+++ b/tests/integration/test_absolute_freq_point_a.py
@@ -23,136 +23,115 @@ class TestDLAbsoluteFrequencyPointA:
             (Frequency.from_mhz("700.3"), Frequency.from_mhz(10), 654321),
             (Frequency.from_mhz(3500), Frequency.from_mhz(100), 987654),
             (Frequency.from_mhz(3925), Frequency.from_mhz(20), 661000),
+            (Frequency.from_mhz(25000), Frequency.from_mhz(20), 2029000),
+            (Frequency.from_mhz("24000.523"), Frequency.from_mhz(20), 1999368),
         ],
     )
-    def test_get_dl_absolute_frequency_point_a_when_arfcn_from_frequency_is_mocked_then_return_value_of_arfcn_object_macthes_expected_value(  # noqa: E501
-            self, center_freq, bandwidth, expected_arfcn_value
+    def test_get_dl_absolute_frequency_point_a_when_valid_inputs_given_then_return_expected_values(  # noqa: E501
+        self, center_freq, bandwidth, expected_arfcn_value
     ):
-        with patch.object(
-                ARFCN,
-                "from_frequency",
-                return_value=ARFCN(expected_arfcn_value),
-        ):
-            result = get_dl_absolute_frequency_point_a(center_freq, bandwidth)
-            assert isinstance(result, ARFCN)
-            assert result._channel == expected_arfcn_value
+        result = get_dl_absolute_frequency_point_a(center_freq, bandwidth)
+        assert isinstance(result, ARFCN)
+        assert result._channel == expected_arfcn_value
 
     @pytest.mark.parametrize(
-        "center_freq, bandwidth, expected_arfcn_value",
+        "center_freq, bandwidth, expected_lowest_freq",
         [
-            (Frequency.from_mhz(1000), Frequency.from_mhz("20.43"), 123456),
-            (Frequency.from_mhz("700.3"), Frequency.from_mhz(10), 654321),
-            (Frequency.from_mhz(3500), Frequency.from_mhz(100), 987654),
-            (Frequency.from_mhz(3925), Frequency.from_mhz(20), 661000),
+            (Frequency.from_mhz(1000), Frequency.from_mhz("20.43"), Frequency.from_mhz(989.785)),  # type: ignore
+            (Frequency.from_mhz("700.3"), Frequency.from_mhz(10), Frequency.from_mhz(695.3)),  # type: ignore
+            (Frequency.from_mhz(3500), Frequency.from_mhz(100), Frequency.from_mhz(3450)),
+            (Frequency.from_mhz(3925), Frequency.from_mhz(20), Frequency.from_mhz(3915)),
         ],
     )
-    def test_get_dl_absolute_frequency_point_a_when_when_arfcn_from_frequency_is_mocked_then_lowest_frequency_passed_to_arfcn_calculation_is_correct(  # noqa: E501
-            self, center_freq, bandwidth, expected_arfcn_value
+    def test_get_dl_absolute_frequency_point_a_when_valid_inputs_given_then_get_expected_lowest_freq_calculation(  # noqa: E501
+        self, center_freq, bandwidth, expected_lowest_freq
     ):
-        expected_lowest_freq = center_freq - (bandwidth / CONFIG_CONSTANT_TWO)
-        with patch.object(
-                ARFCN, "from_frequency", return_value=ARFCN(expected_arfcn_value)
-        ) as mock_from_frequency:
-            result = get_dl_absolute_frequency_point_a(center_freq, bandwidth)
-            mock_from_frequency.assert_called_once_with(expected_lowest_freq)
-            assert result._channel == expected_arfcn_value
+        actual_lowest_freq = center_freq - (bandwidth / CONFIG_CONSTANT_TWO)
+        assert actual_lowest_freq == expected_lowest_freq
+        result = get_dl_absolute_frequency_point_a(center_freq, bandwidth)
+        assert isinstance(result, ARFCN)
 
     @pytest.mark.parametrize(
         "center_freq, bandwidth, expected_exception, expected_msg",
         [
             (
-                    "invalid",
-                    Frequency.from_mhz(20),
-                    DLAbsoluteFrequencyPointAError,
-                    "decimal.ConversionSyntax",
+                "invalid",
+                Frequency.from_mhz(20),
+                DLAbsoluteFrequencyPointAError,
+                "decimal.ConversionSyntax",
             ),
             (
-                    Frequency.from_mhz(1000),
-                    "20",
-                    DLAbsoluteFrequencyPointAError,
-                    "unsupported operand type(s) for /: 'str' and 'decimal.Decimal'",
+                Frequency.from_mhz(1000),
+                "20",
+                DLAbsoluteFrequencyPointAError,
+                "unsupported operand type(s) for /: 'str' and 'decimal.Decimal'",
             ),
             (
-                    None,
-                    Frequency.from_mhz(20),
-                    DLAbsoluteFrequencyPointAError,
-                    "Unsupported type for subtraction: <class 'NoneType'>",
+                None,
+                Frequency.from_mhz(20),
+                DLAbsoluteFrequencyPointAError,
+                "Unsupported type for subtraction: <class 'NoneType'>",
             ),
         ],
     )
     def test_get_dl_absolute_frequency_point_a_when_invalid_inputs_given_then_raise_error(
-            self, center_freq, bandwidth, expected_exception, expected_msg
+        self, center_freq, bandwidth, expected_exception, expected_msg
     ):
         with patch.object(
-                ARFCN,
-                "from_frequency",
+            ARFCN,
+            "from_frequency",
         ):
             with pytest.raises(expected_exception) as err:
                 get_dl_absolute_frequency_point_a(center_freq, bandwidth)
             assert expected_msg in str(err.value)
 
     def test_get_dl_absolute_frequency_point_a_when_decimal_invalid_operation_error_raised_then_handle_and_raise_dl_absolute_frequency_point_a_error(  # noqa: E501
-            self,
-    ):  # noqa: E501
+        self,
+    ):
         with patch.object(
-                ARFCN,
-                "from_frequency",
-                side_effect=decimal.InvalidOperation("Invalid decimal operation"),
+            ARFCN,
+            "from_frequency",
+            side_effect=decimal.InvalidOperation("Invalid decimal operation"),
         ):
             center_freq = Frequency.from_mhz(1000)
             bandwidth = Frequency.from_mhz(20)
             with pytest.raises(
-                    DLAbsoluteFrequencyPointAError,
-                    match="Error calculating downlink absolute frequency Point A.*Invalid decimal operation",  # noqa: E501
+                DLAbsoluteFrequencyPointAError,
+                match="Error calculating downlink absolute frequency Point A.*Invalid decimal operation",  # noqa: E501
             ):
                 get_dl_absolute_frequency_point_a(center_freq, bandwidth)
-
-    @pytest.mark.parametrize(
-        "center_freq, bandwidth, expected_value",
-        [
-            (Frequency.from_mhz(3925), Frequency.from_mhz(20), 661000),
-            (Frequency.from_mhz(1000), Frequency.from_mhz(50), 195000),
-            (Frequency.from_mhz(25000), Frequency.from_mhz(20), 2029000),
-            (Frequency.from_mhz("24000.523"), Frequency.from_mhz(20), 1999368),
-        ],
-    )
-    def test_get_dl_absolute_frequency_point_a_when_valid_values_provided_and_no_mock_used_then_get_expected_values(  # noqa: E501
-            self, center_freq, bandwidth, expected_value
-    ):
-        result = get_dl_absolute_frequency_point_a(center_freq, bandwidth)
-        assert result == ARFCN(expected_value)
 
     @pytest.mark.parametrize(
         "center_freq, bandwidth, expected_exception, expected_msg",
         [
             (
-                    Frequency.from_mhz(392533333),
-                    Frequency.from_mhz(20),
-                    DLAbsoluteFrequencyPointAError,
-                    "Frequency 392533323000000 is out of supported range.",
+                Frequency.from_mhz(392533333),
+                Frequency.from_mhz(20),
+                DLAbsoluteFrequencyPointAError,
+                "Frequency 392533323000000 is out of supported range.",
             ),
             (
-                    Frequency.from_mhz(-1000),
-                    Frequency.from_mhz(50),
-                    DLAbsoluteFrequencyPointAError,
-                    "Frequency -1025000000 is out of supported range.",
+                Frequency.from_mhz(-1000),
+                Frequency.from_mhz(50),
+                DLAbsoluteFrequencyPointAError,
+                "Frequency -1025000000 is out of supported range.",
             ),
             (
-                    None,
-                    Frequency.from_mhz(20),
-                    DLAbsoluteFrequencyPointAError,
-                    "Unsupported type for subtraction: <class 'NoneType'>",
+                None,
+                Frequency.from_mhz(20),
+                DLAbsoluteFrequencyPointAError,
+                "Unsupported type for subtraction: <class 'NoneType'>",
             ),
             (
-                    "24000.523",
-                    Frequency.from_mhz(20),
-                    DLAbsoluteFrequencyPointAError,
-                    "Frequency -9975999.477 is out of supported range",
+                "24000.523",
+                Frequency.from_mhz(20),
+                DLAbsoluteFrequencyPointAError,
+                "Frequency -9975999.477 is out of supported range",
             ),
         ],
     )
     def test_get_dl_absolute_frequency_point_a_when_invalid_values_provided_then_dl_absolute_frequency_point_a_error_raised(  # noqa: E501
-            self, center_freq, bandwidth, expected_exception, expected_msg
+        self, center_freq, bandwidth, expected_exception, expected_msg
     ):
         with pytest.raises(expected_exception) as err:
             get_dl_absolute_frequency_point_a(center_freq, bandwidth)

--- a/tests/integration/test_absolute_freq_point_a.py
+++ b/tests/integration/test_absolute_freq_point_a.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import decimal
+from unittest.mock import patch
+
+import pytest
+
+from src.du_parameters.dl_absolute_freq_point_a import (
+    CONFIG_CONSTANT_TWO,
+    DLAbsoluteFrequencyPointAError,
+    get_dl_absolute_frequency_point_a,
+)
+from src.du_parameters.frequency import ARFCN, Frequency
+
+
+class TestDLAbsoluteFrequencyPointA:
+    @pytest.mark.parametrize(
+        "center_freq, bandwidth, expected_arfcn_value",
+        [
+            (Frequency.from_mhz(1000), Frequency.from_mhz("20.43"), 123456),
+            (Frequency.from_mhz("700.3"), Frequency.from_mhz(10), 654321),
+            (Frequency.from_mhz(3500), Frequency.from_mhz(100), 987654),
+            (Frequency.from_mhz(3925), Frequency.from_mhz(20), 661000),
+        ],
+    )
+    def test_get_dl_absolute_frequency_point_a_when_arfcn_from_frequency_is_mocked_then_return_value_of_arfcn_object_macthes_expected_value(  # noqa: E501
+            self, center_freq, bandwidth, expected_arfcn_value
+    ):
+        with patch.object(
+                ARFCN,
+                "from_frequency",
+                return_value=ARFCN(expected_arfcn_value),
+        ):
+            result = get_dl_absolute_frequency_point_a(center_freq, bandwidth)
+            assert isinstance(result, ARFCN)
+            assert result._channel == expected_arfcn_value
+
+    @pytest.mark.parametrize(
+        "center_freq, bandwidth, expected_arfcn_value",
+        [
+            (Frequency.from_mhz(1000), Frequency.from_mhz("20.43"), 123456),
+            (Frequency.from_mhz("700.3"), Frequency.from_mhz(10), 654321),
+            (Frequency.from_mhz(3500), Frequency.from_mhz(100), 987654),
+            (Frequency.from_mhz(3925), Frequency.from_mhz(20), 661000),
+        ],
+    )
+    def test_get_dl_absolute_frequency_point_a_when_when_arfcn_from_frequency_is_mocked_then_lowest_frequency_passed_to_arfcn_calculation_is_correct(  # noqa: E501
+            self, center_freq, bandwidth, expected_arfcn_value
+    ):
+        expected_lowest_freq = center_freq - (bandwidth / CONFIG_CONSTANT_TWO)
+        with patch.object(
+                ARFCN, "from_frequency", return_value=ARFCN(expected_arfcn_value)
+        ) as mock_from_frequency:
+            result = get_dl_absolute_frequency_point_a(center_freq, bandwidth)
+            mock_from_frequency.assert_called_once_with(expected_lowest_freq)
+            assert result._channel == expected_arfcn_value
+
+    @pytest.mark.parametrize(
+        "center_freq, bandwidth, expected_exception, expected_msg",
+        [
+            (
+                    "invalid",
+                    Frequency.from_mhz(20),
+                    DLAbsoluteFrequencyPointAError,
+                    "decimal.ConversionSyntax",
+            ),
+            (
+                    Frequency.from_mhz(1000),
+                    "20",
+                    DLAbsoluteFrequencyPointAError,
+                    "unsupported operand type(s) for /: 'str' and 'decimal.Decimal'",
+            ),
+            (
+                    None,
+                    Frequency.from_mhz(20),
+                    DLAbsoluteFrequencyPointAError,
+                    "Unsupported type for subtraction: <class 'NoneType'>",
+            ),
+        ],
+    )
+    def test_get_dl_absolute_frequency_point_a_when_invalid_inputs_given_then_raise_error(
+            self, center_freq, bandwidth, expected_exception, expected_msg
+    ):
+        with patch.object(
+                ARFCN,
+                "from_frequency",
+        ):
+            with pytest.raises(expected_exception) as err:
+                get_dl_absolute_frequency_point_a(center_freq, bandwidth)
+            assert expected_msg in str(err.value)
+
+    def test_get_dl_absolute_frequency_point_a_when_decimal_invalid_operation_error_raised_then_handle_and_raise_dl_absolute_frequency_point_a_error(  # noqa: E501
+            self,
+    ):  # noqa: E501
+        with patch.object(
+                ARFCN,
+                "from_frequency",
+                side_effect=decimal.InvalidOperation("Invalid decimal operation"),
+        ):
+            center_freq = Frequency.from_mhz(1000)
+            bandwidth = Frequency.from_mhz(20)
+            with pytest.raises(
+                    DLAbsoluteFrequencyPointAError,
+                    match="Error calculating downlink absolute frequency Point A.*Invalid decimal operation",  # noqa: E501
+            ):
+                get_dl_absolute_frequency_point_a(center_freq, bandwidth)
+
+    @pytest.mark.parametrize(
+        "center_freq, bandwidth, expected_value",
+        [
+            (Frequency.from_mhz(3925), Frequency.from_mhz(20), 661000),
+            (Frequency.from_mhz(1000), Frequency.from_mhz(50), 195000),
+            (Frequency.from_mhz(25000), Frequency.from_mhz(20), 2029000),
+            (Frequency.from_mhz("24000.523"), Frequency.from_mhz(20), 1999368),
+        ],
+    )
+    def test_get_dl_absolute_frequency_point_a_when_valid_values_provided_and_no_mock_used_then_get_expected_values(  # noqa: E501
+            self, center_freq, bandwidth, expected_value
+    ):
+        result = get_dl_absolute_frequency_point_a(center_freq, bandwidth)
+        assert result == ARFCN(expected_value)
+
+    @pytest.mark.parametrize(
+        "center_freq, bandwidth, expected_exception, expected_msg",
+        [
+            (
+                    Frequency.from_mhz(392533333),
+                    Frequency.from_mhz(20),
+                    DLAbsoluteFrequencyPointAError,
+                    "Frequency 392533323000000 is out of supported range.",
+            ),
+            (
+                    Frequency.from_mhz(-1000),
+                    Frequency.from_mhz(50),
+                    DLAbsoluteFrequencyPointAError,
+                    "Frequency -1025000000 is out of supported range.",
+            ),
+            (
+                    None,
+                    Frequency.from_mhz(20),
+                    DLAbsoluteFrequencyPointAError,
+                    "Unsupported type for subtraction: <class 'NoneType'>",
+            ),
+            (
+                    "24000.523",
+                    Frequency.from_mhz(20),
+                    DLAbsoluteFrequencyPointAError,
+                    "Frequency -9975999.477 is out of supported range",
+            ),
+        ],
+    )
+    def test_get_dl_absolute_frequency_point_a_when_invalid_values_provided_then_dl_absolute_frequency_point_a_error_raised(  # noqa: E501
+            self, center_freq, bandwidth, expected_exception, expected_msg
+    ):
+        with pytest.raises(expected_exception) as err:
+            get_dl_absolute_frequency_point_a(center_freq, bandwidth)
+        assert expected_msg in str(err.value)

--- a/tests/unit/test_absolute_freq_point_a.py
+++ b/tests/unit/test_absolute_freq_point_a.py
@@ -3,8 +3,6 @@
 # See LICENSE file for licensing details.
 
 import decimal
-from unittest.mock import patch
-
 import pytest
 
 from src.du_parameters.dl_absolute_freq_point_a import (
@@ -85,29 +83,10 @@ class TestDLAbsoluteFrequencyPointA:
     def test_get_dl_absolute_frequency_point_a_when_invalid_inputs_given_then_raise_error(
         self, center_freq, bandwidth, expected_exception, expected_msg
     ):
-        with patch.object(
-            ARFCN,
-            "from_frequency",
-        ):
-            with pytest.raises(expected_exception) as err:
-                get_dl_absolute_frequency_point_a(center_freq, bandwidth)
-            assert expected_msg in str(err.value)
+        with pytest.raises(expected_exception) as err:
+            get_dl_absolute_frequency_point_a(center_freq, bandwidth)
+        assert expected_msg in str(err.value)
 
-    def test_get_dl_absolute_frequency_point_a_when_decimal_invalid_operation_error_raised_then_handle_and_raise_dl_absolute_frequency_point_a_error(  # noqa: E501
-        self,
-    ):
-        with patch.object(
-            ARFCN,
-            "from_frequency",
-            side_effect=decimal.InvalidOperation("Invalid decimal operation"),
-        ):
-            center_freq = Frequency.from_mhz(1000)
-            bandwidth = Frequency.from_mhz(20)
-            with pytest.raises(
-                DLAbsoluteFrequencyPointAError,
-                match="Error calculating downlink absolute frequency Point A.*Invalid decimal operation",  # noqa: E501
-            ):
-                get_dl_absolute_frequency_point_a(center_freq, bandwidth)
 
     @pytest.mark.parametrize(
         "center_freq, bandwidth, expected_exception, expected_msg",

--- a/tests/unit/test_absolute_freq_point_a.py
+++ b/tests/unit/test_absolute_freq_point_a.py
@@ -19,9 +19,9 @@ class TestDLAbsoluteFrequencyPointA:
     @pytest.mark.parametrize(
         "center_freq, bandwidth, expected_arfcn_value",
         [
-            (Frequency.from_mhz(1000), Frequency.from_mhz("20.43"), 123456),
-            (Frequency.from_mhz("700.3"), Frequency.from_mhz(10), 654321),
-            (Frequency.from_mhz(3500), Frequency.from_mhz(100), 987654),
+            (Frequency.from_mhz(1000), Frequency.from_mhz("20.43"), 197957),
+            (Frequency.from_mhz("700.3"), Frequency.from_mhz(10), 139060),
+            (Frequency.from_mhz(3500), Frequency.from_mhz(100), 630000),
             (Frequency.from_mhz(3925), Frequency.from_mhz(20), 661000),
             (Frequency.from_mhz(25000), Frequency.from_mhz(20), 2029000),
             (Frequency.from_mhz("24000.523"), Frequency.from_mhz(20), 1999368),
@@ -37,8 +37,16 @@ class TestDLAbsoluteFrequencyPointA:
     @pytest.mark.parametrize(
         "center_freq, bandwidth, expected_lowest_freq",
         [
-            (Frequency.from_mhz(1000), Frequency.from_mhz("20.43"), Frequency.from_mhz(989.785)),  # type: ignore
-            (Frequency.from_mhz("700.3"), Frequency.from_mhz(10), Frequency.from_mhz(695.3)),  # type: ignore
+            (
+                Frequency.from_mhz(1000),
+                Frequency.from_mhz("20.43"),
+                Frequency(str(989784999.9999999681676854379)),
+            ),
+            (
+                Frequency.from_mhz("700.3"),
+                Frequency.from_mhz(10),
+                Frequency(str(695299999.9999999545252649114)),
+            ),
             (Frequency.from_mhz(3500), Frequency.from_mhz(100), Frequency.from_mhz(3450)),
             (Frequency.from_mhz(3925), Frequency.from_mhz(20), Frequency.from_mhz(3915)),
         ],
@@ -58,7 +66,7 @@ class TestDLAbsoluteFrequencyPointA:
                 "invalid",
                 Frequency.from_mhz(20),
                 DLAbsoluteFrequencyPointAError,
-                "decimal.ConversionSyntax",
+                "Unsupported type for subtraction: <class 'str'>",
             ),
             (
                 Frequency.from_mhz(1000),
@@ -108,13 +116,13 @@ class TestDLAbsoluteFrequencyPointA:
                 Frequency.from_mhz(392533333),
                 Frequency.from_mhz(20),
                 DLAbsoluteFrequencyPointAError,
-                "Frequency 392533323000000 is out of supported range.",
+                "No frequency range found for frequency 392533323000000",
             ),
             (
                 Frequency.from_mhz(-1000),
                 Frequency.from_mhz(50),
                 DLAbsoluteFrequencyPointAError,
-                "Frequency -1025000000 is out of supported range.",
+                "No frequency range found for frequency -1025000000",
             ),
             (
                 None,
@@ -126,7 +134,7 @@ class TestDLAbsoluteFrequencyPointA:
                 "24000.523",
                 Frequency.from_mhz(20),
                 DLAbsoluteFrequencyPointAError,
-                "Frequency -9975999.477 is out of supported range",
+                "No frequency range found for frequency -9975999.477",
             ),
         ],
     )

--- a/tests/unit/test_absolute_freq_point_a.py
+++ b/tests/unit/test_absolute_freq_point_a.py
@@ -2,7 +2,6 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import decimal
 import pytest
 
 from src.du_parameters.dl_absolute_freq_point_a import (
@@ -86,7 +85,6 @@ class TestDLAbsoluteFrequencyPointA:
         with pytest.raises(expected_exception) as err:
             get_dl_absolute_frequency_point_a(center_freq, bandwidth)
         assert expected_msg in str(err.value)
-
 
     @pytest.mark.parametrize(
         "center_freq, bandwidth, expected_exception, expected_msg",


### PR DESCRIPTION
# Description

According to https://docs.google.com/document/d/1f_SPGr5COHTlTbrmJjzYkDrBjvhEeR9XH8JPc8DZa_Q/edit?tab=t.0#heading=h.g8k4gpndinhw, calculate DL AbsoluteFrequencyPointA using Frequency and ARFCN classes.


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library