### PR TITLE
feat: calculate initial BWP location and Bandwidth

### DIFF
--- a/src/du_parameters/initial_bwp.py
+++ b/src/du_parameters/initial_bwp.py
@@ -74,10 +74,6 @@ def calculate_initial_bwp(carrier_bandwidth: int, subcarrier_spacing: Frequency)
     Returns:
         int: The calculated initialBWP location and bandwidth.
     """
-    if not isinstance(carrier_bandwidth, int):
-        logger.error("Carrier bandwidth must be an integer, not %s", type(carrier_bandwidth))
-        raise TypeError(f"Carrier bandwidth must be an integer, not {type(carrier_bandwidth)}")
-
     if carrier_bandwidth <= 0:
         logger.error("Carrier bandwidth must be greater than 0.")
         raise ValueError("Carrier bandwidth must be greater than 0.")

--- a/src/du_parameters/initial_bwp.py
+++ b/src/du_parameters/initial_bwp.py
@@ -33,11 +33,6 @@ def get_total_prbs_from_scs(subcarrier_spacing: Frequency) -> int:
         ValueError: If the Subcarrier spacing value is not supported.
         TypeError: If the Subcarrier spacing is not a Frequency object.
     """
-    if not isinstance(subcarrier_spacing, Frequency):
-        raise TypeError(
-            f"Subcarrier spacing must be a Frequency object, not {type(subcarrier_spacing)}"
-        )
-
     scs_to_prbs = {
         Frequency.from_khz(15): 275,
         Frequency.from_khz(30): 137,
@@ -47,7 +42,7 @@ def get_total_prbs_from_scs(subcarrier_spacing: Frequency) -> int:
     try:
         return scs_to_prbs[subcarrier_spacing]
     except KeyError:
-        supported_subcarrier_spacing = ", ".join(str(freq) for freq in scs_to_prbs.keys())
+        supported_subcarrier_spacing = ", ".join(str(freq) for freq in scs_to_prbs)
         logger.error(
             "Subcarrier spacing value: %s is not supported. Supported values: %s",
             subcarrier_spacing,
@@ -79,14 +74,6 @@ def calculate_initial_bwp(carrier_bandwidth: int, subcarrier_spacing: Frequency)
     Returns:
         int: The calculated initialBWP location and bandwidth.
     """
-    if not isinstance(subcarrier_spacing, Frequency):
-        logger.error(
-            "Subcarrier spacing must be a Frequency object, not %s", type(subcarrier_spacing)
-        )
-        raise TypeError(
-            f"Subcarrier spacing must be a Frequency object, not {type(subcarrier_spacing)}"
-        )
-
     if not isinstance(carrier_bandwidth, int):
         logger.error("Carrier bandwidth must be an integer, not %s", type(carrier_bandwidth))
         raise TypeError(f"Carrier bandwidth must be an integer, not {type(carrier_bandwidth)}")

--- a/src/du_parameters/initial_bwp.py
+++ b/src/du_parameters/initial_bwp.py
@@ -1,0 +1,123 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Calculate Initial BWP location And Bandwidth.
+
+Uses subcarrier spacing and carrier bandwidth as inputs.
+"""
+
+import logging
+
+from src.du_parameters.frequency import Frequency
+
+logger = logging.getLogger(__name__)
+
+
+class CalculateBWPLocationBandwidthError(Exception):
+    """Exception raised when calculation of BWP location and bandwidth fails."""
+
+    pass
+
+
+def get_total_prbs_from_scs(subcarrier_spacing: Frequency) -> int:
+    """Get the number of Physical Resource Blocks (PRBs) based on Subcarrier Spacing (SCS).
+
+    Args:
+        subcarrier_spacing (Frequency): Subcarrier Spacing as Frequency object.
+        Valid values: 15, 30, 60, 120.
+
+    Returns:
+        int: Number of PRBs for given Subcarrier spacing value.
+
+    Raises:
+        ValueError: If the Subcarrier spacing value is not supported.
+        TypeError: If the Subcarrier spacing is not a Frequency object.
+    """
+    if not isinstance(subcarrier_spacing, Frequency):
+        raise TypeError(
+            f"Subcarrier spacing must be a Frequency object, not {type(subcarrier_spacing)}"
+        )
+
+    scs_to_prbs = {
+        Frequency.from_khz(15): 275,
+        Frequency.from_khz(30): 137,
+        Frequency.from_khz(60): 69,
+        Frequency.from_khz(120): 33,
+    }
+    try:
+        return scs_to_prbs[subcarrier_spacing]
+    except KeyError:
+        supported_subcarrier_spacing = ", ".join(str(freq) for freq in scs_to_prbs.keys())
+        logger.error(
+            "Subcarrier spacing value: %s is not supported. Supported values: %s",
+            subcarrier_spacing,
+            supported_subcarrier_spacing,
+        )
+        raise ValueError(
+            f"Subcarrier spacing value {subcarrier_spacing} is not supported."
+            f"Supported values: {supported_subcarrier_spacing}"
+        )
+
+
+def calculate_initial_bwp(carrier_bandwidth: int, subcarrier_spacing: Frequency) -> int:
+    """Calculate the initial BWP location and bandwidth.
+
+    Uses carrier bandwidth and Subcarrier Spacing.
+
+    Formula:
+        initialBWPlocationAndBandwidth (int) = (Total_PRB * (L - 1)) + RBstart
+        RBstart (int) = 0 the starting resource block for initial BWP location
+        Total_PRB (int) = Total number of Physical Resource Blocks (PRBs) based
+         on Subcarrier Spacing (SCS)
+        L (int) = Carrier bandwidth
+
+    Args:
+        carrier_bandwidth (int): Channel bandwidths of the carrier in terms of Resource Blocks.
+                                Indicated as L in the formula.
+        subcarrier_spacing (Frequency): Subcarrier Spacing in Frequency object.
+
+    Returns:
+        int: The calculated initialBWP location and bandwidth.
+    """
+    if not isinstance(subcarrier_spacing, Frequency):
+        logger.error(
+            "Subcarrier spacing must be a Frequency object, not %s", type(subcarrier_spacing)
+        )
+        raise TypeError(
+            f"Subcarrier spacing must be a Frequency object, not {type(subcarrier_spacing)}"
+        )
+
+    if not isinstance(carrier_bandwidth, int):
+        logger.error("Carrier bandwidth must be an integer, not %s", type(carrier_bandwidth))
+        raise TypeError(f"Carrier bandwidth must be an integer, not {type(carrier_bandwidth)}")
+
+    if carrier_bandwidth <= 0:
+        logger.error("Carrier bandwidth must be greater than 0.")
+        raise ValueError("Carrier bandwidth must be greater than 0.")
+
+    try:
+        total_prb = get_total_prbs_from_scs(subcarrier_spacing)
+    except (ValueError, TypeError) as err:
+        logger.error(
+            "Error calculating total PRBs using "
+            "carrier_bandwidth: %s and subcarrier spacing: %s: %s",
+            carrier_bandwidth,
+            subcarrier_spacing,
+            str(err),
+        )
+
+        raise CalculateBWPLocationBandwidthError(
+            f"Error calculating total PRBs using"
+            f" {carrier_bandwidth} and {subcarrier_spacing}: {str(err)}"
+        ) from err
+
+    rb_start = 0
+    initial_bwp = (total_prb * (carrier_bandwidth - 1)) + rb_start
+    logger.info(
+        "Calculated initial BWP location and bandwidth using"
+        " carrier_bandwidth: %s and subcarrier spacing: %s: %s",
+        carrier_bandwidth,
+        subcarrier_spacing,
+        initial_bwp,
+    )
+    return initial_bwp

--- a/tests/unit/test_initial_bwp.py
+++ b/tests/unit/test_initial_bwp.py
@@ -71,19 +71,18 @@ class TestCalculateInitialBWP:
         assert calculate_initial_bwp(carrier_bandwidth, scs) == expected_bwp
 
     @pytest.mark.parametrize(
-        "carrier_bandwidth",
+        "carrier_bandwidth, error_type, error_message",
         [
-            "invalid",
-            None,
-            4.23,
+            ("invalid", TypeError, "'<=' not supported between instances of 'str' and 'int'"),
+            (None, TypeError, "'<=' not supported between instances of 'NoneType' and 'int'"),
         ],
     )
-    def test_calculate_initial_bwp_when_invalid_type_carrier_bandwidth_given_then_raise_type_error(
-        self, carrier_bandwidth
+    def test_calculate_initial_bwp_when_invalid_type_carrier_bandwidth_given_then_it_raises_error(
+        self, carrier_bandwidth, error_type, error_message
     ):
-        with pytest.raises(TypeError) as e:
+        with pytest.raises(error_type) as e:
             calculate_initial_bwp(carrier_bandwidth, Frequency.from_khz(15))
-        assert "Carrier bandwidth must be an integer" in str(e.value)
+        assert error_message in str(e.value)
 
     @pytest.mark.parametrize(
         "scs",

--- a/tests/unit/test_initial_bwp.py
+++ b/tests/unit/test_initial_bwp.py
@@ -1,0 +1,113 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+import pytest
+
+from src.du_parameters.frequency import GSCN, Frequency
+from src.du_parameters.initial_bwp import (
+    CalculateBWPLocationBandwidthError,
+    calculate_initial_bwp,
+    get_total_prbs_from_scs,
+)
+
+
+class TestGetTotalPRBs:
+    @pytest.mark.parametrize(
+        "scs,expected_prbs",
+        [
+            (Frequency.from_khz(15), 275),
+            (Frequency.from_khz(30), 137),
+            (Frequency.from_khz(60), 69),
+            (Frequency.from_khz(120), 33),
+        ],
+    )
+    def test_get_total_prbs_from_scs_when_valid_inputs_given_then_return_expected_results(
+        self, scs, expected_prbs
+    ):
+        assert get_total_prbs_from_scs(scs) == expected_prbs
+
+    @pytest.mark.parametrize(
+        "scs",
+        [
+            "invalid",
+            None,
+            3.43,
+            23232,
+        ],
+    )
+    def test_get_total_prbs_from_scs_when_invalid_type_inputs_given_then_raise_type_error(
+        self, scs
+    ):
+        with pytest.raises(TypeError, match="Subcarrier spacing must be a Frequency object"):
+            get_total_prbs_from_scs(scs)
+
+    def test_get_total_prbs_from_scs_when_unsupported_value_given_then_raise_value_error(self):
+        invalid_scs = Frequency.from_khz(10)
+        with pytest.raises(
+            ValueError,
+            match="Subcarrier spacing value 10000 is not supported."
+            "Supported values: 15000, 30000, 60000, 120000",
+        ):
+            get_total_prbs_from_scs(invalid_scs)
+
+
+class TestCalculateInitialBWP:
+    @pytest.mark.parametrize(
+        "carrier_bandwidth,scs,expected_bwp",
+        [
+            (1, Frequency.from_khz(15), 0),
+            (2, Frequency.from_khz(15), 275),
+            (3, Frequency.from_khz(30), 274),
+            (1, Frequency.from_khz(60), 0),
+            (4, Frequency.from_khz(120), 99),
+        ],
+    )
+    def test_calculate_initial_bwp_when_valid_inputs_given_then_return_expected_results(
+        self, carrier_bandwidth, scs, expected_bwp
+    ):
+        assert calculate_initial_bwp(carrier_bandwidth, scs) == expected_bwp
+
+    @pytest.mark.parametrize(
+        "carrier_bandwidth",
+        [
+            "invalid",
+            None,
+            4.23,
+        ],
+    )
+    def test_calculate_initial_bwp_when_invalid_type_carrier_bandwidth_given_then_raise_type_error(
+        self, carrier_bandwidth
+    ):
+        with pytest.raises(TypeError) as e:
+            calculate_initial_bwp(carrier_bandwidth, Frequency.from_khz(15))
+        assert "Carrier bandwidth must be an integer" in str(e.value)
+
+    @pytest.mark.parametrize(
+        "scs",
+        [
+            "invalid",
+            None,
+            4.23,
+            GSCN(23),
+        ],
+    )
+    def test_calculate_initial_bwp_when_invalid_type_scs_given_then_raise_type_error(self, scs):
+        with pytest.raises(TypeError, match="Subcarrier spacing must be a Frequency object"):
+            calculate_initial_bwp(1, scs)
+
+    def test_calculate_initial_bwp__when_unsupported_carrier_bandwidth_value_given_then_raise_value_error(  # noqa: E501
+        self,
+    ):
+        with pytest.raises(ValueError) as e:
+            calculate_initial_bwp(0, Frequency.from_khz(15))
+        assert "Carrier bandwidth must be greater than 0" in str(e.value)
+
+    def test_calculate_initial_bwp_when_get_total_prb_calculation_fails_then_raise_calculate_bwp_location_bandwidth_error(  # noqa: E501
+        self,
+    ):
+        with pytest.raises(
+            CalculateBWPLocationBandwidthError,
+            match="Error calculating total PRBs using 2 and 10000: "
+            "Subcarrier spacing value 10000 is not supported."
+            "Supported values: 15000, 30000, 60000, 120000",
+        ):
+            calculate_initial_bwp(2, Frequency.from_khz(10))

--- a/tests/unit/test_initial_bwp.py
+++ b/tests/unit/test_initial_bwp.py
@@ -37,7 +37,11 @@ class TestGetTotalPRBs:
     def test_get_total_prbs_from_scs_when_invalid_type_inputs_given_then_raise_type_error(
         self, scs
     ):
-        with pytest.raises(TypeError, match="Subcarrier spacing must be a Frequency object"):
+        with pytest.raises(
+            ValueError,
+            match=f"Subcarrier spacing value {scs} is not supported."
+            f"Supported values: 15000, 30000, 60000, 120000",
+        ):
             get_total_prbs_from_scs(scs)
 
     def test_get_total_prbs_from_scs_when_unsupported_value_given_then_raise_value_error(self):
@@ -91,7 +95,9 @@ class TestCalculateInitialBWP:
         ],
     )
     def test_calculate_initial_bwp_when_invalid_type_scs_given_then_raise_type_error(self, scs):
-        with pytest.raises(TypeError, match="Subcarrier spacing must be a Frequency object"):
+        with pytest.raises(
+            CalculateBWPLocationBandwidthError, match="Error calculating total PRBs"
+        ):
             calculate_initial_bwp(1, scs)
 
     def test_calculate_initial_bwp__when_unsupported_carrier_bandwidth_value_given_then_raise_value_error(  # noqa: E501


### PR DESCRIPTION
# Description

According to https://docs.google.com/document/d/1f_SPGr5COHTlTbrmJjzYkDrBjvhEeR9XH8JPc8DZa_Q/edit?tab=t.0#heading=h.1h3sstuzfc29,  this PR calculates BWPlocationAndBandwidth which depends on Carrier Bandwidth (int type) and Subcarrier Spacing (Frequency type) parameters:

- Total PRB is calculated according Subcarrier Spacing which is given in Table 4 in the spec TE-129. 
- RBstart is zero for initial BWP.
- L is the CarrierBandwith.

Formula:
```
initialBWPlocationAndBandwidth = (Total_PRB *(L-1))+RBstart
```

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library