### PR TITLE
feat: expose config options for RAN configuration

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -75,12 +75,14 @@ config:
       description: |
         This parameter enables three-quarter sampling on DU by adding -E flag to DU startup command. This flag might be required to split 8 sample rate to run DU connected to physical devices (such as USRP B210).
     center-frequency:
-      type: string
+      type: str
+      default: "4060"
       description: |
         The frequency which is permitted by statutory regulations given in MHz in FR1 5G spectrum.
         FR1 5G covers potential spectrum offerings from 410 MHz to 7125 MHz.
     bandwidth:
       type: integer
+      default: 40
       description: |
         The width of radio frequencies, centered on the center frequency given in MHz. 
         The supported bandwidth in FR1 5G is between 5 MHz to 100 MHz.

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -77,7 +77,7 @@ config:
     center-frequency:
       type: string
       description: |
-        Middle frequency of the band to use for this DU. The frequency needs to be in the 5G FR1 range, from 410 MHz to 7125 MHz.
+        Middle frequency (in MHz) of the band to use for this DU. The frequency needs to be in the 5G FR1 range, from 410 MHz to 7125 MHz.
     bandwidth:
       type: int
       description: |

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -74,7 +74,29 @@ config:
       default: false
       description: |
         This parameter enables three-quarter sampling on DU by adding -E flag to DU startup command. This flag might be required to split 8 sample rate to run DU connected to physical devices (such as USRP B210).
-
+    center-frequency:
+      type: string
+      description: |
+        The frequency which is permitted by statutory regulations given in MHz in FR1 5G spectrum.
+        FR1 5G covers potential spectrum offerings from 410 MHz to 7125 MHz.
+    bandwidth:
+      type: integer
+      description: |
+        The width of radio frequencies, centered on the center frequency given in MHz. 
+        The supported bandwidth in FR1 5G is between 5 MHz to 100 MHz.
+    frequency-band:
+      type: integer
+      default: 77
+      description: |
+        Prefix of N in FR1. A frequency range which is defined in FR1 5G TDD spectrum.
+        The supported prefixes of N in FR1 5G band is one of the defined values:
+        34, 38, 39, 40, 41, 46, 47, 48, 50, 51, 53, 54, 77, 78, 79, 90, 96, 101, 102, 104, 105.
+    sub-carrier-spacing:
+      type: integer
+      default: 30
+      description: | 
+        The distance between two adjacent sub-carriers given in KHZ. 
+        As FR1 5G spectrum supports 15, 30, 60 KHz sub-carrier spacing, it should be one of these values.
 parts:
   charm:
     source: .

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -75,27 +75,23 @@ config:
       description: |
         This parameter enables three-quarter sampling on DU by adding -E flag to DU startup command. This flag might be required to split 8 sample rate to run DU connected to physical devices (such as USRP B210).
     center-frequency:
-      type: str
-      default: "4060"
+      type: string
       description: |
-        The frequency which is permitted by statutory regulations given in MHz in FR1 5G spectrum.
+        The reference point or middle of an allocated band of frequencies within the 5G FR1 spectrum range.
         FR1 5G covers potential spectrum offerings from 410 MHz to 7125 MHz.
     bandwidth:
-      type: integer
-      default: 40
+      type: int
       description: |
         The width of radio frequencies, centered on the center frequency given in MHz. 
         The supported bandwidth in FR1 5G is between 5 MHz to 100 MHz.
     frequency-band:
-      type: integer
-      default: 77
+      type: int
       description: |
         Prefix of N in FR1. A frequency range which is defined in FR1 5G TDD spectrum.
         The supported prefixes of N in FR1 5G band is one of the defined values:
-        34, 38, 39, 40, 41, 46, 47, 48, 50, 51, 53, 54, 77, 78, 79, 90, 96, 101, 102, 104, 105.
+        34, 38, 39, 40, 41, 46, 47, 48, 50, 51, 53, 54, 77, 78, 79, 90, 96, 101, 102.
     sub-carrier-spacing:
-      type: integer
-      default: 30
+      type: int
       description: | 
         The distance between two adjacent sub-carriers given in KHZ. 
         As FR1 5G spectrum supports 15, 30, 60 KHz sub-carrier spacing, it should be one of these values.

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -77,8 +77,7 @@ config:
     center-frequency:
       type: string
       description: |
-        The reference point or middle of an allocated band of frequencies within the 5G FR1 spectrum range.
-        FR1 5G covers potential spectrum offerings from 410 MHz to 7125 MHz.
+        Middle frequency of the band to use for this DU. The frequency needs to be in the 5G FR1 range, from 410 MHz to 7125 MHz.
     bandwidth:
       type: int
       description: |
@@ -87,8 +86,8 @@ config:
     frequency-band:
       type: int
       description: |
-        Prefix of N in FR1. A frequency range which is defined in FR1 5G TDD spectrum.
-        The supported prefixes of N in FR1 5G band is one of the defined values:
+        5G NR frequency band, without the 'N' prefix. The chosen band must be
+        in the FR1 range and use TDD multiplexing. The supported bands are:
         34, 38, 39, 40, 41, 46, 47, 48, 50, 51, 53, 54, 77, 78, 79, 90, 96, 101, 102.
     sub-carrier-spacing:
       type: int

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -93,8 +93,8 @@ config:
     sub-carrier-spacing:
       type: int
       description: | 
-        The distance between two adjacent sub-carriers given in KHZ. 
-        As FR1 5G spectrum supports 15, 30, 60 KHz sub-carrier spacing, it should be one of these values.
+        The distance between two adjacent sub-carriers given in kHz. 
+        As FR1 5G spectrum supports 15, 30, 60 kHz sub-carrier spacing, it should be one of these values.
 parts:
   charm:
     source: .

--- a/src/charm.py
+++ b/src/charm.py
@@ -36,7 +36,7 @@ from du_parameters.absolute_freq_ssb import get_absolute_frequency_ssb
 from du_parameters.carrier_bandwidth import get_carrier_bandwidth
 from du_parameters.dl_absolute_freq_point_a import get_dl_absolute_frequency_point_a
 from du_parameters.frequency import ARFCN, Frequency
-from du_parameters.initial_bwp import calculate_initial_bwp
+from du_parameters.initial_bwp import get_initial_bwp
 from oai_ran_du_k8s import DUSecurityContext, DUUSBVolume
 
 logger = logging.getLogger(__name__)
@@ -272,23 +272,19 @@ class OAIRANDUOperator(CharmBase):
             plmns=remote_network_config.plmns,
             simulation_mode=self._charm_config.simulation_mode,
             frequency_band=self._charm_config.frequency_band,
-            sub_carrier_spacing=_get_numerology(
-                Frequency.from_khz(self._charm_config.sub_carrier_spacing)
-            ),
-            absolute_frequency_ssb=get_absolute_frequency_ssb(
-                Frequency.from_mhz(self._charm_config.center_frequency)
-            ),
+            sub_carrier_spacing=_get_numerology(self._charm_config.sub_carrier_spacing),
+            absolute_frequency_ssb=get_absolute_frequency_ssb(self._charm_config.center_frequency),
             dl_absolute_frequency_point_a=get_dl_absolute_frequency_point_a(
-                Frequency.from_mhz(self._charm_config.center_frequency),
-                Frequency.from_mhz(self._charm_config.bandwidth),
-                Frequency.from_khz(self._charm_config.sub_carrier_spacing),
+                self._charm_config.center_frequency,
+                self._charm_config.bandwidth,
+                self._charm_config.sub_carrier_spacing,
             ),
             dl_carrier_bandwidth=self._get_carrier_bandwidth(),
             ul_carrier_bandwidth=self._get_carrier_bandwidth(),
-            initial_dl_bwp_location_and_bandwidth=calculate_initial_bwp(
+            initial_dl_bwp_location_and_bandwidth=get_initial_bwp(
                 self._get_carrier_bandwidth(),
             ),
-            initial_ul_bwp_location_and_bandwidth=calculate_initial_bwp(
+            initial_ul_bwp_location_and_bandwidth=get_initial_bwp(
                 self._get_carrier_bandwidth(),
             ),
         ).rstrip()
@@ -296,8 +292,8 @@ class OAIRANDUOperator(CharmBase):
     def _get_carrier_bandwidth(self) -> int:
         """Return the carrier bandwidth."""
         return get_carrier_bandwidth(
-            Frequency.from_mhz(self._charm_config.bandwidth),
-            Frequency.from_khz(self._charm_config.sub_carrier_spacing),
+            self._charm_config.bandwidth,
+            self._charm_config.sub_carrier_spacing,
         )
 
     def _generate_network_annotations(self) -> List[NetworkAnnotation]:

--- a/src/charm.py
+++ b/src/charm.py
@@ -33,11 +33,11 @@ from ops.pebble import Layer
 
 from charm_config import CharmConfig, CharmConfigInvalidError, CNIType
 from oai_ran_du_k8s import DUSecurityContext, DUUSBVolume
-from src.du_parameters.absolute_freq_ssb import get_absolute_frequency_ssb
-from src.du_parameters.carrier_bandwidth import get_carrier_bandwidth
-from src.du_parameters.dl_absolute_freq_point_a import get_dl_absolute_frequency_point_a
-from src.du_parameters.frequency import ARFCN, Frequency
-from src.du_parameters.initial_bwp import calculate_initial_bwp
+from du_parameters.absolute_freq_ssb import get_absolute_frequency_ssb
+from du_parameters.carrier_bandwidth import get_carrier_bandwidth
+from du_parameters.dl_absolute_freq_point_a import get_dl_absolute_frequency_point_a
+from du_parameters.frequency import ARFCN, Frequency
+from du_parameters.initial_bwp import calculate_initial_bwp
 
 logger = logging.getLogger(__name__)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -32,12 +32,12 @@ from ops.charm import CharmBase
 from ops.pebble import Layer
 
 from charm_config import CharmConfig, CharmConfigInvalidError, CNIType
-from oai_ran_du_k8s import DUSecurityContext, DUUSBVolume
 from du_parameters.absolute_freq_ssb import get_absolute_frequency_ssb
 from du_parameters.carrier_bandwidth import get_carrier_bandwidth
 from du_parameters.dl_absolute_freq_point_a import get_dl_absolute_frequency_point_a
 from du_parameters.frequency import ARFCN, Frequency
 from du_parameters.initial_bwp import calculate_initial_bwp
+from oai_ran_du_k8s import DUSecurityContext, DUUSBVolume
 
 logger = logging.getLogger(__name__)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -6,6 +6,7 @@
 
 import json
 import logging
+from functools import lru_cache
 from ipaddress import IPv4Address
 from subprocess import check_output
 from typing import List, Optional, Tuple
@@ -32,11 +33,14 @@ from ops.charm import CharmBase
 from ops.pebble import Layer
 
 from charm_config import CharmConfig, CharmConfigInvalidError, CNIType
-from du_parameters.absolute_freq_ssb import get_absolute_frequency_ssb
-from du_parameters.carrier_bandwidth import get_carrier_bandwidth
-from du_parameters.dl_absolute_freq_point_a import get_dl_absolute_frequency_point_a
-from du_parameters.frequency import ARFCN, Frequency
-from du_parameters.initial_bwp import get_initial_bwp
+from du_parameters import (
+    ARFCN,
+    Frequency,
+    get_absolute_frequency_ssb,
+    get_carrier_bandwidth,
+    get_dl_absolute_frequency_point_a,
+    get_initial_bwp,
+)
 from oai_ran_du_k8s import DUSecurityContext, DUUSBVolume
 
 logger = logging.getLogger(__name__)
@@ -289,6 +293,7 @@ class OAIRANDUOperator(CharmBase):
             ),
         ).rstrip()
 
+    @lru_cache
     def _get_carrier_bandwidth(self) -> int:
         """Return the carrier bandwidth."""
         return get_carrier_bandwidth(

--- a/src/charm.py
+++ b/src/charm.py
@@ -287,11 +287,9 @@ class OAIRANDUOperator(CharmBase):
             ul_carrier_bandwidth=self._get_carrier_bandwidth(),
             initial_dl_bwp_location_and_bandwidth=calculate_initial_bwp(
                 self._get_carrier_bandwidth(),
-                Frequency.from_khz(self._charm_config.sub_carrier_spacing),
             ),
             initial_ul_bwp_location_and_bandwidth=calculate_initial_bwp(
                 self._get_carrier_bandwidth(),
-                Frequency.from_khz(self._charm_config.sub_carrier_spacing),
             ),
         ).rstrip()
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -266,6 +266,14 @@ class OAIRANDUOperator(CharmBase):
             tac=remote_network_config.tac,
             plmns=remote_network_config.plmns,
             simulation_mode=self._charm_config.simulation_mode,
+            absoluteFrequencySSB=None,
+            frequencyBand=None,
+            dl_absoluteFrequencyPointA=None,
+            subcarrierSpacing=None,
+            dl_carrierBandwidth=None,
+            initialDLBWPlocationAndBandwidth=None,
+            ul_carrierBandwidth=None,
+            initialULBWPlocationAndBandwidth=None,
         ).rstrip()
 
     def _generate_network_annotations(self) -> List[NetworkAnnotation]:

--- a/src/charm.py
+++ b/src/charm.py
@@ -554,13 +554,13 @@ def _get_pod_ip() -> Optional[str]:
 
 
 def _get_numerology(sub_carrier_spacing: Frequency) -> int:
-    mapping = {
+    scs_to_numerology = {
         Frequency.from_khz(15): 0,
         Frequency.from_khz(30): 1,
         Frequency.from_khz(60): 2,
     }
-    if sub_carrier_spacing in mapping:
-        return mapping[sub_carrier_spacing]
+    if sub_carrier_spacing in scs_to_numerology:
+        return scs_to_numerology[sub_carrier_spacing]
     raise ValueError(f"Unsupported sub-carrier spacing: {sub_carrier_spacing}")
 
 

--- a/src/charm_config.py
+++ b/src/charm_config.py
@@ -206,7 +206,7 @@ class DUConfig(BaseModel):  # pylint: disable=too-few-public-methods
     @field_validator("sub_carrier_spacing", mode="before")
     @classmethod
     def validate_sub_carrier_spacing(cls, sub_carrier_spacing: int, info: ValidationInfo):
-        """Validate the subcarrier spacing."""
+        """Validate the sub carrier spacing."""
         frequency_band = info.data.get("frequency_band")
         bandwidth = info.data.get("bandwidth")
         if frequency_band is None:

--- a/src/charm_config.py
+++ b/src/charm_config.py
@@ -8,6 +8,7 @@ import dataclasses
 import logging
 from enum import Enum
 from ipaddress import ip_network
+from typing import Optional, Tuple
 
 import ops
 from pydantic import (  # pylint: disable=no-name-in-module,import-error
@@ -17,6 +18,7 @@ from pydantic import (  # pylint: disable=no-name-in-module,import-error
     ValidationError,
     field_validator,
 )
+from src.du_parameters.frequency import Frequency
 from pydantic_core.core_schema import ValidationInfo
 
 logger = logging.getLogger(__name__)
@@ -33,6 +35,10 @@ class CharmConfigInvalidError(Exception):
         """
         self.msg = msg
 
+class FrequencyBandNotFoundError(Exception):
+    """Custom exception raised when the band N number is not found."""
+    pass
+
 
 class CNIType(str, Enum):
     """Class to define available CNI types for CU operator."""
@@ -44,6 +50,119 @@ class CNIType(str, Enum):
 def to_kebab(name: str) -> str:
     """Convert a snake_case string to kebab-case."""
     return name.replace("_", "-")
+
+TDD_FR1_BANDS = {
+    # band_number: ( frequency range in MHz)
+    34: (2010, 2025),
+    38: (2570, 2620),
+    39: (1880, 1920),
+    40: (2300, 2400),
+    41: (2496, 2690),
+    48: (3550, 3700),
+    50: (1432, 1517),
+    51: (1427, 1432),
+    77: (3300, 4200),
+    78: (3300, 3800),
+    79: (4400, 5000),
+    90: (2496, 2690),
+    96: (5925, 7125),
+    101: (1900, 1910),
+    102: (5925, 6425),
+}
+
+
+ALLOWED_CHANNEL_BANDWIDTHS = {
+    # frequency_band: {sub_carrier_spacing (KHz): {allowed_bandwidths (MHz)}}
+    34: {
+        15: {5, 10, 15},
+        30: {10, 15},
+        60: {10, 15},
+    },
+    38: {
+        15: {5, 10, 15, 20, 25, 30, 40},
+        30: {10, 15, 20, 25, 30, 40},
+        60: {10, 15, 20, 25, 30, 40},
+    },
+    39: {
+        15: {5, 10, 15, 20, 25, 30, 40},
+        30: {10, 15, 20, 25, 30, 40},
+        60: {10, 15, 20, 25, 30, 40},
+    },
+    40: {
+        15: {5, 10, 15, 20, 25, 30, 40, 50},
+        30: {10, 15, 20, 25, 30, 40, 50, 60, 80},
+        60: {10, 15, 20, 25, 30, 40, 50, 60, 80},
+    },
+    41: {
+        15: {10, 15, 20, 30, 40, 50},
+        30: {10, 15, 20, 30, 40, 50, 60, 80, 90, 100},
+        60: {10, 15, 20, 30, 40, 50, 60, 80, 90, 100},
+    },
+    48: {
+        15: {5, 10, 15, 20, 40, 50},
+        30: {10, 15, 20, 40, 50, 60, 80, 90, 100},
+        60: {10, 15, 20, 40, 50, 60, 80, 90, 100},
+    },
+    50: {
+        15: {5, 10, 15, 20, 30, 40, 50},
+        30: {10, 15, 20, 30, 40, 50, 60, 80},
+        60: {10, 15, 20, 30, 40, 50, 60, 80},
+    },
+    51: {
+        15: {5},
+    },
+    77: {
+        15: {10, 15, 20, 25, 30, 40, 50},
+        30: {10, 15, 20, 25, 30, 40, 50, 60, 70, 80, 90, 100},
+        60: {10, 15, 20, 25, 30, 40, 50, 60, 70, 80, 90, 100},
+    },
+    78: {
+        15: {10, 15, 20, 25, 30, 40, 50},
+        30: {10, 15, 20, 25, 30, 40, 50, 60, 70, 80, 90, 100},
+        60: {10, 15, 20, 25, 30, 40, 50, 60, 70, 80, 90, 100},
+    },
+    79: {
+        15: {40, 50},
+        30: {40, 50, 60, 80, 100},
+        60: {40, 50, 60, 80, 100},
+    },
+    90: {
+        15: {10, 15, 20, 30, 40, 50},
+        30: {10, 15, 20, 30, 40, 50, 60, 80, 90, 100},
+        60: {10, 15, 20, 30, 40, 50, 60, 80, 90, 100},
+    },
+    96: {
+        15: {20, 40},
+        30: {20, 40, 60, 80},
+    },
+    101: {
+        15: {5, 10},
+        30: {10},
+    },
+    102: {
+        15: {20, 40},
+        30: {20, 40, 60, 80, 100},
+        60: {20, 40, 60, 80, 100},
+    },
+}
+
+def get_tdd_uplink_downlink(band: int) -> Tuple[int, int]:
+    """Retrieve uplink and downlink frequency ranges for a given TDD N number (band).
+
+    Args:
+        band (int): The N number (such as 34, 38, 77, etc.)
+
+    Returns:
+        Optional[Tuple[int, int]]: A tuple of uplink and downlink frequencies (MHz).
+
+    Raises:
+        FrequencyBandNotFoundError: If the band N number is not found in TDD FR1 bands.
+    """
+    if band not in TDD_FR1_BANDS:
+        logger.error("Frequency band N: %s is not found in TDD FR1 bands.", band)
+        raise FrequencyBandNotFoundError(f"Frequency band N: {band} is not found in TDD FR1 bands.")
+
+    return TDD_FR1_BANDS[band]
 
 
 class DUConfig(BaseModel):  # pylint: disable=too-few-public-methods
@@ -60,6 +179,10 @@ class DUConfig(BaseModel):  # pylint: disable=too-few-public-methods
     f1_port: int = Field(ge=1, le=65535)
     simulation_mode: bool = False
     use_three_quarter_sampling: bool = False
+    center_frequency: str = Field(ge="410", le="7125")
+    bandwidth: int = Field(ge=5, le=100)
+    frequency_band: int = Field(default=77, ge=34, le=102)
+    sub_carrier_spacing: int = Field(default=30, ge=15, le=60)
 
     @field_validator("f1_ip_address", mode="before")
     @classmethod
@@ -68,6 +191,94 @@ class DUConfig(BaseModel):  # pylint: disable=too-few-public-methods
         ip_network(value, strict=False)
         return value
 
+    @field_validator("sub_carrier_spacing")
+    @classmethod
+    def validate_sub_carrier_spacing(cls, sub_carrier_spacing: int, values):
+        """Validate that the subcarrier spacing is valid for the frequency band and channel bandwidth."""
+        frequency_band = values.get("frequency_band")
+        bandwidth = values.get("bandwidth")
+
+        if bandwidth is None:
+            logger.error("Bandwidth must be defined before validating sub_carrier_spacing.")
+            raise ValueError(
+                "Bandwidth must be defined before validating sub_carrier_spacing."
+            )
+        try:
+            # Retrieve allowed bandwidths for the current frequency band and subcarrier spacing
+            allowed_bandwidths_by_spacing = ALLOWED_CHANNEL_BANDWIDTHS[frequency_band]
+        except KeyError:
+            logger.error("Invalid frequency_band: %s. No subcarrier spacing data available.", frequency_band)
+            raise ValueError(f"Invalid frequency_band: {frequency_band}. No subcarrier spacing data available.")
+
+        try:
+            allowed_bandwidths = allowed_bandwidths_by_spacing[sub_carrier_spacing]
+        except KeyError:
+            logger.error("Sub_carrier_spacing %s is not allowed for the specified frequency_band %s.", sub_carrier_spacing, frequency_band)
+            raise ValueError(
+                f"Sub_carrier_spacing {sub_carrier_spacing} is not allowed for the specified frequency_band {frequency_band}."
+            )
+
+        if bandwidth not in allowed_bandwidths:
+            logger.error("Bandwidth: %s MHz is not allowed for the frequency_band %s with sub_carrier_spacing %s. Allowed bandwidths: %s",
+                         bandwidth, frequency_band, sub_carrier_spacing, sorted(allowed_bandwidths)
+                         )
+            raise ValueError(
+                f"Bandwidth {bandwidth} MHz is not allowed for the frequency_band {frequency_band} with "
+                f"sub_carrier_spacing {sub_carrier_spacing}. Allowed bandwidths: {sorted(allowed_bandwidths)}"
+            )
+
+        return sub_carrier_spacing
+
+
+    @field_validator("bandwidth", mode="before")
+    @classmethod
+    def validate_bandwidth(cls, value):
+        allowed_values = {5, 10, 15, 20, 25, 30, 40, 50, 60, 70, 80, 90, 100}
+        if value not in allowed_values:
+            logger.error("Bandwidth must be one of %s", allowed_values)
+            raise ValueError(f"Bandwidth must be one of {allowed_values}")
+        return value
+
+    @field_validator("frequency_band", mode="before")
+    @classmethod
+    def validate_frequency_band(cls, value):
+        if value not in TDD_FR1_BANDS:
+            logger.error("Bandwidth must be one of the defined values: %s", TDD_FR1_BANDS.keys())
+            raise ValueError(f"Bandwidth must be one of the defined values:", TDD_FR1_BANDS.keys())
+        return value
+
+    @field_validator("center_frequency", mode="before")
+    @classmethod
+    def validate_center_frequency(cls, center_frequency: str, values):
+        """Validate if the center frequency is within the uplink-downlink range after considering bandwidth.
+            Args:
+                center_frequency (str): The center frequency to validate.
+                values (dict): The values of the other fields.
+        """
+        frequency_band = values.get("frequency_band")
+        bandwidth = values.get("bandwidth")
+
+        if bandwidth is None:
+            raise ValueError("Bandwidth must be defined before validating center_frequency.")
+
+        try:
+            band_start, band_end = get_tdd_uplink_downlink(frequency_band)
+        except FrequencyBandNotFoundError:
+            logger.error("Invalid frequency_band: %s. No uplink-downlink range found.", frequency_band)
+            raise ValueError(f"Invalid frequency_band: {frequency_band}. No uplink-downlink range found.")
+
+        # Find usable range in Hz for center frequency based on bandwidth
+        usable_start = Frequency.from_mhz(band_start) + (Frequency.from_mhz(bandwidth) // 2)
+        usable_end = Frequency.from_mhz(band_end) - (Frequency.from_mhz(bandwidth) // 2)
+
+        if not (usable_start <= Frequency.from_mhz(center_frequency) <= usable_end):
+            logger.error("Center_frequency %s must be within the usable range [%s Hz, %s Hz] for the given bandwidth %s MHz.",
+                         center_frequency, usable_start, usable_end, bandwidth)
+            raise ValueError(
+                f"Center_frequency {center_frequency} must be within the usable range "
+                f"[{usable_start} Hz, {usable_end} Hz] for the given bandwidth {bandwidth} MHz."
+            )
+        return center_frequency
 
 @dataclasses.dataclass
 class CharmConfig:

--- a/src/charm_config.py
+++ b/src/charm_config.py
@@ -20,7 +20,7 @@ from pydantic import (  # pylint: disable=no-name-in-module,import-error
 )
 from pydantic_core.core_schema import ValidationInfo
 
-from src.du_parameters.frequency import Frequency
+from du_parameters.frequency import Frequency
 
 logger = logging.getLogger(__name__)
 

--- a/src/charm_config.py
+++ b/src/charm_config.py
@@ -366,9 +366,9 @@ class CharmConfig:
     simulation_mode: bool
     use_three_quarter_sampling: bool
     frequency_band: int
-    sub_carrier_spacing: int
-    bandwidth: int
-    center_frequency: str
+    sub_carrier_spacing: Frequency
+    bandwidth: Frequency
+    center_frequency: Frequency
 
     def __init__(self, *, du_config: DUConfig):
         """Initialize a new instance of the CharmConfig class.
@@ -383,9 +383,9 @@ class CharmConfig:
         self.simulation_mode = du_config.simulation_mode
         self.use_three_quarter_sampling = du_config.use_three_quarter_sampling
         self.frequency_band = du_config.frequency_band
-        self.sub_carrier_spacing = du_config.sub_carrier_spacing
-        self.bandwidth = du_config.bandwidth
-        self.center_frequency = du_config.center_frequency
+        self.sub_carrier_spacing = Frequency.from_khz(du_config.sub_carrier_spacing)
+        self.bandwidth = Frequency.from_mhz(du_config.bandwidth)
+        self.center_frequency = Frequency.from_mhz(du_config.center_frequency)
 
     @classmethod
     def from_charm(

--- a/src/charm_config.py
+++ b/src/charm_config.py
@@ -75,7 +75,7 @@ TDD_FR1_BANDS = {
     102: (5925, 6425),
 }
 
-# The reference of allowed channel bandwidths: https://www.nrexplained.com/bandwidth Table 5.3.5-1
+# The reference of channel bandwidths for each NR band: 3GPP TS 38.101-1 version 17.5.0 Table 5.3.5-1
 ALLOWED_CHANNEL_BANDWIDTHS = {
     # frequency_band: {sub_carrier_spacing (KHz): {allowed_bandwidths (MHz)}}
     34: {

--- a/src/charm_config.py
+++ b/src/charm_config.py
@@ -193,7 +193,7 @@ class DUConfig(BaseModel):  # pylint: disable=too-few-public-methods
     frequency_band: int = Field(ge=34, le=102)
     sub_carrier_spacing: int = Field(ge=15, le=60)
     center_frequency: str = Field(
-        pattern=r"^\d+(\.\d+)?$", description="Center frequency as an integer or a float"
+        description="Center frequency as an integer or a float wrapped as str."
     )
 
     @field_validator("f1_ip_address", mode="before")

--- a/src/charm_config.py
+++ b/src/charm_config.py
@@ -55,6 +55,7 @@ def to_kebab(name: str) -> str:
     return name.replace("_", "-")
 
 
+# The reference of TDD FR1 bands: https://en.wikipedia.org/wiki/5G_NR_frequency_bands
 TDD_FR1_BANDS = {
     # band_number: ( frequency range in MHz)
     34: (2010, 2025),
@@ -74,7 +75,7 @@ TDD_FR1_BANDS = {
     102: (5925, 6425),
 }
 
-
+# The reference of allowed channel bandwidths: https://www.nrexplained.com/bandwidth Table 5.3.5-1
 ALLOWED_CHANNEL_BANDWIDTHS = {
     # frequency_band: {sub_carrier_spacing (KHz): {allowed_bandwidths (MHz)}}
     34: {
@@ -186,10 +187,12 @@ class DUConfig(BaseModel):  # pylint: disable=too-few-public-methods
     f1_port: int = Field(ge=1, le=65535)
     simulation_mode: bool = False
     use_three_quarter_sampling: bool = False
-    bandwidth: int = Field(default=40, ge=5, le=100)
-    frequency_band: int = Field(default=77, ge=34, le=102)
-    sub_carrier_spacing: int = Field(default=30, ge=15, le=60)
-    center_frequency: str = Field(default="4060")
+    bandwidth: int = Field(ge=5, le=100)
+    frequency_band: int = Field(ge=34, le=102)
+    sub_carrier_spacing: int = Field(ge=15, le=60)
+    center_frequency: str = Field(
+        pattern=r"^\d+(\.\d+)?$", description="Center frequency as an integer or a float"
+    )
 
     @field_validator("f1_ip_address", mode="before")
     @classmethod

--- a/src/du_parameters/__init__.py
+++ b/src/du_parameters/__init__.py
@@ -1,0 +1,41 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+"""DU Parameters."""
+
+from .absolute_freq_ssb import AbsoluteFrequencySSBError, get_absolute_frequency_ssb
+from .carrier_bandwidth import get_carrier_bandwidth
+from .dl_absolute_freq_point_a import (
+    CONFIG_CONSTANT_TWO,
+    DLAbsoluteFrequencyPointAError,
+    get_dl_absolute_frequency_point_a,
+)
+from .frequency import (
+    ARFCN,
+    HIGH_FREQUENCY,
+    LOW_FREQUENCY,
+    MID_FREQUENCY,
+    Frequency,
+    GetRangeFromFrequencyError,
+    GetRangeFromGSCNError,
+)
+from .guard_band import GuardBandError, get_minimum_guard_band
+from .initial_bwp import get_initial_bwp
+
+__all__ = [
+    "get_absolute_frequency_ssb",
+    "get_carrier_bandwidth",
+    "get_dl_absolute_frequency_point_a",
+    "ARFCN",
+    "Frequency",
+    "get_initial_bwp",
+    "AbsoluteFrequencySSBError",
+    "get_minimum_guard_band",
+    "GuardBandError",
+    "HIGH_FREQUENCY",
+    "LOW_FREQUENCY",
+    "MID_FREQUENCY",
+    "GetRangeFromGSCNError",
+    "GetRangeFromFrequencyError",
+    "CONFIG_CONSTANT_TWO",
+    "DLAbsoluteFrequencyPointAError",
+]

--- a/src/du_parameters/absolute_freq_ssb.py
+++ b/src/du_parameters/absolute_freq_ssb.py
@@ -6,7 +6,7 @@
 import decimal
 import logging
 
-from frequency import (
+from du_parameters.frequency import (
     ARFCN,
     GSCN,
     Frequency,

--- a/src/du_parameters/absolute_freq_ssb.py
+++ b/src/du_parameters/absolute_freq_ssb.py
@@ -6,7 +6,7 @@
 import decimal
 import logging
 
-from src.du_parameters.frequency import (
+from frequency import (
     ARFCN,
     GSCN,
     Frequency,

--- a/src/du_parameters/absolute_freq_ssb.py
+++ b/src/du_parameters/absolute_freq_ssb.py
@@ -6,7 +6,7 @@
 import decimal
 import logging
 
-from du_parameters.frequency import (
+from .frequency import (
     ARFCN,
     GSCN,
     Frequency,

--- a/src/du_parameters/carrier_bandwidth.py
+++ b/src/du_parameters/carrier_bandwidth.py
@@ -7,10 +7,10 @@ import decimal
 import logging
 from decimal import Decimal
 
-from src.du_parameters.frequency import (
+from frequency import (
     Frequency,
 )
-from src.du_parameters.guard_band import GuardBandError, get_minimum_guard_band
+from guard_band import GuardBandError, get_minimum_guard_band
 
 logger = logging.getLogger(__name__)
 

--- a/src/du_parameters/carrier_bandwidth.py
+++ b/src/du_parameters/carrier_bandwidth.py
@@ -7,10 +7,10 @@ import decimal
 import logging
 from decimal import Decimal
 
-from frequency import (
+from du_parameters.frequency import (
     Frequency,
 )
-from guard_band import GuardBandError, get_minimum_guard_band
+from du_parameters.guard_band import GuardBandError, get_minimum_guard_band
 
 logger = logging.getLogger(__name__)
 

--- a/src/du_parameters/carrier_bandwidth.py
+++ b/src/du_parameters/carrier_bandwidth.py
@@ -7,10 +7,10 @@ import decimal
 import logging
 from decimal import Decimal
 
-from du_parameters.frequency import (
+from .frequency import (
     Frequency,
 )
-from du_parameters.guard_band import GuardBandError, get_minimum_guard_band
+from .guard_band import GuardBandError, get_minimum_guard_band
 
 logger = logging.getLogger(__name__)
 

--- a/src/du_parameters/dl_absolute_freq_point_a.py
+++ b/src/du_parameters/dl_absolute_freq_point_a.py
@@ -44,6 +44,9 @@ def get_dl_absolute_frequency_point_a(
         lowest_freq = center_freq - (bandwidth / CONFIG_CONSTANT_TWO)
         # Align the lowest frequency to the channel raster
         aligned_lowest_freq = round(lowest_freq / sub_carrier_spacing) * sub_carrier_spacing
+        # Ensure aligned_lowest_freq is not less than lowest_freq
+        if aligned_lowest_freq < lowest_freq:
+            aligned_lowest_freq += sub_carrier_spacing
         arfcn = ARFCN.from_frequency(Frequency(aligned_lowest_freq))
         logger.info("Calculated downlink absolute frequency Point A: %s", arfcn)
         return arfcn

--- a/src/du_parameters/dl_absolute_freq_point_a.py
+++ b/src/du_parameters/dl_absolute_freq_point_a.py
@@ -7,7 +7,7 @@ import decimal
 import logging
 from decimal import Decimal
 
-from du_parameters.frequency import (
+from .frequency import (
     ARFCN,
     Frequency,
     GetRangeFromFrequencyError,
@@ -26,7 +26,7 @@ class DLAbsoluteFrequencyPointAError(Exception):
 
 def get_dl_absolute_frequency_point_a(
     center_freq: Frequency, bandwidth: Frequency, sub_carrier_spacing: Frequency
-) -> ARFCN:
+) -> "ARFCN":
     """Calculate downlink absolute frequency Point A using center frequency and bandwidth.
 
     Args:

--- a/src/du_parameters/dl_absolute_freq_point_a.py
+++ b/src/du_parameters/dl_absolute_freq_point_a.py
@@ -24,12 +24,15 @@ class DLAbsoluteFrequencyPointAError(Exception):
     pass
 
 
-def get_dl_absolute_frequency_point_a(center_freq: Frequency, bandwidth: Frequency) -> ARFCN:
+def get_dl_absolute_frequency_point_a(
+    center_freq: Frequency, bandwidth: Frequency, sub_carrier_spacing: Frequency
+) -> ARFCN:
     """Calculate downlink absolute frequency Point A using center frequency and bandwidth.
 
     Args:
         center_freq (Frequency): Center frequency
         bandwidth (Frequency): Bandwidth
+        sub_carrier_spacing (Frequency): Subcarrier spacing
 
     Returns:
         ARFCN: The dl absolute frequency point A in ARFCN format
@@ -39,7 +42,9 @@ def get_dl_absolute_frequency_point_a(center_freq: Frequency, bandwidth: Frequen
     """
     try:
         lowest_freq = center_freq - (bandwidth / CONFIG_CONSTANT_TWO)
-        arfcn = ARFCN.from_frequency(lowest_freq)
+        # Align the lowest frequency to the channel raster
+        aligned_lowest_freq = round(lowest_freq / sub_carrier_spacing) * sub_carrier_spacing
+        arfcn = ARFCN.from_frequency(Frequency(aligned_lowest_freq))
         logger.info("Calculated downlink absolute frequency Point A: %s", arfcn)
         return arfcn
     except (

--- a/src/du_parameters/dl_absolute_freq_point_a.py
+++ b/src/du_parameters/dl_absolute_freq_point_a.py
@@ -7,7 +7,7 @@ import decimal
 import logging
 from decimal import Decimal
 
-from frequency import (
+from du_parameters.frequency import (
     ARFCN,
     Frequency,
     GetRangeFromFrequencyError,

--- a/src/du_parameters/dl_absolute_freq_point_a.py
+++ b/src/du_parameters/dl_absolute_freq_point_a.py
@@ -7,7 +7,7 @@ import decimal
 import logging
 from decimal import Decimal
 
-from src.du_parameters.frequency import (
+from frequency import (
     ARFCN,
     Frequency,
     GetRangeFromFrequencyError,

--- a/src/du_parameters/guard_band.py
+++ b/src/du_parameters/guard_band.py
@@ -5,7 +5,7 @@
 
 import logging
 
-from frequency import Frequency
+from du_parameters.frequency import Frequency
 
 logger = logging.getLogger(__name__)
 

--- a/src/du_parameters/guard_band.py
+++ b/src/du_parameters/guard_band.py
@@ -5,7 +5,7 @@
 
 import logging
 
-from src.du_parameters.frequency import Frequency
+from frequency import Frequency
 
 logger = logging.getLogger(__name__)
 

--- a/src/du_parameters/guard_band.py
+++ b/src/du_parameters/guard_band.py
@@ -5,7 +5,7 @@
 
 import logging
 
-from du_parameters.frequency import Frequency
+from .frequency import Frequency
 
 logger = logging.getLogger(__name__)
 

--- a/src/du_parameters/initial_bwp.py
+++ b/src/du_parameters/initial_bwp.py
@@ -17,8 +17,8 @@ class CalculateBWPLocationBandwidthError(Exception):
     pass
 
 
-def calculate_initial_bwp(carrier_bandwidth: int) -> int:
-    """Calculate the initial BWP location and bandwidth.
+def get_initial_bwp(carrier_bandwidth: int) -> int:
+    """Get the initial BWP location and bandwidth.
 
     Uses carrier bandwidth and Subcarrier Spacing.
 

--- a/src/du_parameters/initial_bwp.py
+++ b/src/du_parameters/initial_bwp.py
@@ -8,7 +8,7 @@ Uses subcarrier spacing and carrier bandwidth as inputs.
 
 import logging
 
-from du_parameters.frequency import Frequency
+from .frequency import Frequency
 
 logger = logging.getLogger(__name__)
 
@@ -33,16 +33,17 @@ def get_total_prbs_from_scs(subcarrier_spacing: Frequency) -> int:
         ValueError: If the Subcarrier spacing value is not supported.
         TypeError: If the Subcarrier spacing is not a Frequency object.
     """
-    scs_to_prbs = {
+    # Maximum bandwidth configurations per SCS for NR frequency bands
+    # Reference TS 38.104 Table 5.3.2.-1
+    scs_to_max_prbs = {
         Frequency.from_khz(15): 275,
-        Frequency.from_khz(30): 137,
-        Frequency.from_khz(60): 69,
-        Frequency.from_khz(120): 33,
+        Frequency.from_khz(30): 275,
+        Frequency.from_khz(60): 135,
     }
     try:
-        return scs_to_prbs[subcarrier_spacing]
+        return scs_to_max_prbs[subcarrier_spacing]
     except KeyError:
-        supported_subcarrier_spacing = ", ".join(str(freq) for freq in scs_to_prbs)
+        supported_subcarrier_spacing = ", ".join(str(freq) for freq in scs_to_max_prbs)
         logger.error(
             "Subcarrier spacing value: %s is not supported. Supported values: %s",
             subcarrier_spacing,

--- a/src/du_parameters/initial_bwp.py
+++ b/src/du_parameters/initial_bwp.py
@@ -8,7 +8,7 @@ Uses subcarrier spacing and carrier bandwidth as inputs.
 
 import logging
 
-from src.du_parameters.frequency import Frequency
+from frequency import Frequency
 
 logger = logging.getLogger(__name__)
 

--- a/src/du_parameters/initial_bwp.py
+++ b/src/du_parameters/initial_bwp.py
@@ -7,16 +7,12 @@ Uses subcarrier spacing and carrier bandwidth as inputs.
 """
 
 import logging
+from functools import lru_cache
 
 logger = logging.getLogger(__name__)
 
 
-class CalculateBWPLocationBandwidthError(Exception):
-    """Exception raised when calculation of BWP location and bandwidth fails."""
-
-    pass
-
-
+@lru_cache
 def get_initial_bwp(carrier_bandwidth: int) -> int:
     """Get the initial BWP location and bandwidth.
 

--- a/src/du_parameters/initial_bwp.py
+++ b/src/du_parameters/initial_bwp.py
@@ -8,7 +8,7 @@ Uses subcarrier spacing and carrier bandwidth as inputs.
 
 import logging
 
-from frequency import Frequency
+from du_parameters.frequency import Frequency
 
 logger = logging.getLogger(__name__)
 

--- a/src/templates/du.conf.j2
+++ b/src/templates/du.conf.j2
@@ -9,6 +9,7 @@ gNBs =
         gNB_DU_ID = 0xe00;
         gNB_name  =  "{{ gnb_name }}";
 
+        # tracking_area_code: TAC specified in the CN
         tracking_area_code = {{ tac }};
         plmn_list =
         (
@@ -33,107 +34,157 @@ gNBs =
         );
         nr_cellid        = 12345678L;
         min_rxtxtime     = 6;
+
+        # do_CSIRS: 1= active if 2x2 MIMO, otherwise not considered. Suggestion, let it active
         do_CSIRS                                                  = 0;
         do_SRS                                                    = 0;
 
+        # force_256qam_off: disable 256 QAM
         force_256qam_off = 1;
 
     servingCellConfigCommon = (
     {
       physCellId                                                    = 0;
-      #frequencyInfoDL
+      # frequencyInfoDL
 
-      # this is 3924.48 MHz (GSCN: 8141)
-      absoluteFrequencySSB                                             = 661632;
-      dl_frequencyBand                                                 = 77;
+      # absoluteFrequencySSB: Frequency-domain position of the SSB
+      absoluteFrequencySSB                                             = {{ absoluteFrequencySSB }};
 
-      # Absolute Frequency of Point A was calculated like this:
-      # center_frequency - (bandwidth / 2)
-      # the bandwidth in this case is 20 MHz, based on numerology 1
-      # and 51 PRBs.
-      # In this case:
-      # 3925 - (20 / 2)
-      # this is 3915 MHz
-      dl_absoluteFrequencyPointA                                       = 660332;
-      #scs-SpecificCarrierList
+      # dl_frequencyBand: The 5G FR1 band
+      dl_frequencyBand                                                 = {{ frequencyBand }};
+
+      # dl_absoluteFrequencyPointA: frequency-location of Point A in downlink
+      dl_absoluteFrequencyPointA                                       = {{ dl_absoluteFrequencyPointA }};
+
+      # dl_offstToCarrier: Offset in the frequency domain between Point A
       dl_offstToCarrier                                              = 0;
-      # subcarrierSpacing
+
+      # dl_subcarrierSpacing: subcarrierSpacing using numerology
       # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
-      dl_subcarrierSpacing                                           = 1;
-      dl_carrierBandwidth                                            = 106;
-      #initialDownlinkBWP
-      #genericParameters
-      # this is RBstart=27,L=48 (275*(L-1))+RBstart
-      initialDLBWPlocationAndBandwidth                               = 28875;
-      # subcarrierSpacing
+      dl_subcarrierSpacing                                           = {{ subcarrierSpacing }};
+
+      # dl_carrierBandwidth: number of PRBs
+      dl_carrierBandwidth                                            = {{ dl_carrierBandwidth }};
+
+      # initialDLBWPlocationAndBandwidth: allows the UE to receive the RRC setup including first RB
+      # and the number of consecutively used RBs
+      initialDLBWPlocationAndBandwidth                               = {{ initialULBWPlocationAndBandwidth }};
+
+      # initialDLBWPsubcarrierSpacing: subcarrierSpacing using numerology
       # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
-      initialDLBWPsubcarrierSpacing                                   = 1;
-      #pdcch-ConfigCommon
+      initialDLBWPsubcarrierSpacing                                   = {{ subcarrierSpacing }};
+
+      # pdcch-ConfigCommon
+      # initialDLBWPcontrolResourceSetZero:BWP that contains all NR channels that are necessary
+      # to conclude the initial access procedure
       initialDLBWPcontrolResourceSetZero                              = 12;
       initialDLBWPsearchSpaceZero                                     = 0;
 
-      #uplinkConfigCommon
-      #frequencyInfoUL
-      ul_frequencyBand                                              = 77;
-      #scs-SpecificCarrierList
+      # uplinkConfigCommon
+      # frequencyInfoUL
+      ul_frequencyBand                                              = {{ frequencyBand }};
+
+      # scs-SpecificCarrierList
+      # ul_offstToCarrier: frequency offset between Point A and the lowest usable subcarrier
+      # in terms of RBs for UL
       ul_offstToCarrier                                             = 0;
-      # subcarrierSpacing
+
+      # ul_subcarrierSpacing: subcarrierSpacing with numerology
       # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
-      ul_subcarrierSpacing                                          = 1;
-      ul_carrierBandwidth                                           = 106;
+      ul_subcarrierSpacing                                          = {{ subcarrierSpacing }};
+
+      # ul_carrierBandwidth: Number of PRBs
+      ul_carrierBandwidth                                           = {{ ul_carrierBandwidth }};
+
       pMax                                                          = 20;
-      #initialUplinkBWP
-      #genericParameters
-      initialULBWPlocationAndBandwidth                            = 28875;
-      # subcarrierSpacing
+
+      # initialUplinkBWP
+      # genericParameters
+      # initialULBWPlocationAndBandwidth: allows the UE to receive the RRC setup including
+      # first RB and the number of consecutively used RBs
+      initialULBWPlocationAndBandwidth                            = {{ initialULBWPlocationAndBandwidth }};
+
+      # initialULBWPsubcarrierSpacing: subcarrierSpacing in numerology
       # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
-      initialULBWPsubcarrierSpacing                               = 1;
-      #rach-ConfigCommon
-      #rach-ConfigGeneric
+      initialULBWPsubcarrierSpacing                               = {{ subcarrierSpacing }};
+
+      # rach-ConfigCommon
+      # rach-ConfigGeneric
+      # prach_ConfigurationIndex: available set of PRACH occasions for the transmission
+      # of the Random Access Preamble
       prach_ConfigurationIndex                                  = 98;
-      #prach_msg1_FDM
-      #0 = one, 1=two, 2=four, 3=eight
+
+      # prach_msg1_FDM
+      # 0 = one, 1=two, 2=four, 3=eight
       prach_msg1_FDM                                            = 0;
       prach_msg1_FrequencyStart                                 = 0;
       zeroCorrelationZoneConfig                                 = 13;
+
+      # preambleReceivedTargetPower: initial Random Access Preamble power
       preambleReceivedTargetPower                               = -96;
-      #preamblTransMax (0...10) = (3,4,5,6,7,8,10,20,50,100,200)
+
+      # preamblTransMax (0...10) = (3,4,5,6,7,8,10,20,50,100,200)
+      # the maximum number of Random Access Preamble transmission
       preambleTransMax                                          = 6;
-      #powerRampingStep
+
+      # powerRampingStep: the power-ramping factor
       # 0=dB0,1=dB2,2=dB4,3=dB6
       powerRampingStep                                            = 1;
-      #ra_ReponseWindow
-      #1,2,4,8,10,20,40,80
+
+      # ra_ReponseWindow: Msg2 (RAR) window length in number of slots
+      # 1,2,4,8,10,20,40,80
       ra_ResponseWindow                                           = 4;
-      #ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR
-      #1=oneeighth,2=onefourth,3=half,4=one,5=two,6=four,7=eight,8=sixteen
+
+      # ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR
+      # 1=oneeighth,2=onefourth,3=half,4=one,5=two,6=four,7=eight,8=sixteen
       ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR                = 4;
-      #oneHalf (0..15) 4,8,12,16,...60,64
+
+      # ssb_perRACH_OccasionAndCB_PreamblesPerSSB: the number of SSBs mapped to each PRACH occasion
+      # and the number of contention-based Random Access Preambles mapped to each SSB
+      # oneHalf (0..15) 4,8,12,16,...60,64
       ssb_perRACH_OccasionAndCB_PreamblesPerSSB                   = 14;
-      #ra_ContentionResolutionTimer
-      #(0..7) 8,16,24,32,40,48,56,64
+
+      # ra_ContentionResolutionTimer
+      # (0..7) 8,16,24,32,40,48,56,64
       ra_ContentionResolutionTimer                                = 7;
+
+      # rsrp_ThresholdSSB: an RSRP threshold for the selection of the SSB
       rsrp_ThresholdSSB                                           = 19;
-      #prach-RootSequenceIndex_PR
-      #1 = 839, 2 = 139
+
+      # prach-RootSequenceIndex_PR: 5G supports four types of long sequence preambles
+      # with a length of 839 and nine types of short sequence
+      # preambles with a length of 139
+      # 1 = 839, 2 = 139
       prach_RootSequenceIndex_PR                                  = 2;
+
+      # prach_RootSequenceIndex: informs the UE on which sequence to use via SIB2
       prach_RootSequenceIndex                                     = 1;
-      # SCS for msg1, can only be 15 for 30 kHz < 6 GHz, takes precedence over the one derived from prach-ConfigIndex
-      #
+
+      # msg1_SubcarrierSpacing: takes precedence over the one derived from prach-ConfigIndex
+      # SCS for msg1, can only be 15 for 30 kHz < 6 GHz
       msg1_SubcarrierSpacing                                      = 1,
-      # restrictedSetConfig
-      # 0=unrestricted, 1=restricted type A, 2=restricted type B
+
+      # restrictedSetConfig: 0=unrestricted, 1=restricted type A, 2=restricted type B
       restrictedSetConfig                                         = 0,
 
+      # msg3_DeltaPreamble: Power offset between msg3 and RACH preamble transmission in steps of 1dB
       msg3_DeltaPreamble                                          = 1;
+
+      # p0_NominalWithGrant: uplink transmission power on the PUSCH which serves as a reference power level
+      # from which adjustments are made based on various factors like path loss
+      # indicates UE power capability
       p0_NominalWithGrant                                         =-90;
 
-      # pucch-ConfigCommon setup :
-      # pucchGroupHopping
-      # 0 = neither, 1= group hopping, 2=sequence hopping
+      # pucch-ConfigCommon setup
+      # pucchGroupHopping: 0 = neither, 1= group hopping, 2=sequence hopping
       pucchGroupHopping                                           = 0;
+
+      # hoppingId: Gets or sets hopping ID for PUCCH Format 1 or 4 configuration
       hoppingId                                                   = 40;
+
+      # p0_nominal: the power for a Pucch transmission
       p0_nominal                                                  = -90;
+
       # ssb_PositionsInBurs_BitmapPR
       # 1=short, 2=medium, 3=long
       ssb_PositionsInBurst_Bitmap                                   = 1;
@@ -146,24 +197,32 @@ gNBs =
       # 0 = pos2, 1 = pos3
       dmrs_TypeA_Position                                           = 0;
 
-      # subcarrierSpacing
+      # subcarrierSpacing with numerology
       # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
-      subcarrierSpacing                                             = 1;
+      subcarrierSpacing                                             = {{ subcarrierSpacing }};
 
-
-      #tdd-UL-DL-ConfigurationCommon
-      # subcarrierSpacing
+      # tdd-UL-DL-ConfigurationCommon
+      # subcarrierSpacing with numerology
       # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
-      referenceSubcarrierSpacing                                    = 1;
-      # pattern1
-      # dl_UL_TransmissionPeriodicity
+      referenceSubcarrierSpacing                                    = {{ subcarrierSpacing }};
+
+      # dl_UL_TransmissionPeriodicity: periodicity indexes
       # 0=ms0p5, 1=ms0p625, 2=ms1, 3=ms1p25, 4=ms2, 5=ms2p5, 6=ms5, 7=ms10
       dl_UL_TransmissionPeriodicity                                 = 6;
+
+      # DL slots
       nrofDownlinkSlots                                             = 7;
+
+      # DL symbols in mixed slots
       nrofDownlinkSymbols                                           = 6;
+
+      # UL slots
       nrofUplinkSlots                                               = 2;
+
+      # UL symbols in mixed slots
       nrofUplinkSymbols                                             = 4;
 
+      # ssPBCH_BlockPower: the power at which gNB transmit the reference signal (SSB block power)
       ssPBCH_BlockPower                                             = -25;
   }
   );
@@ -211,12 +270,23 @@ L1s =
 RUs =
 (
     {
+        # local_rf: indicates the monolithic connection to the SDR
         local_rf                      = "yes"
+
+        # nb_tx: 1 means SISO, 2 means MIMO
         nb_tx                         = 1
+
+        # nb_rx: 1 means SISO, 2 means MIMO
         nb_rx                         = 1
+
+        # att_tx: ranges 6-10 if the UE is close to the B210 antennas. Leave 0 otherwise
         att_tx                        = 12;
+
+        # att_rx: ranges 6-10 if the UE is close to the B210 antennas. Leave 0 otherwise
         att_rx                        = 12;
-        bands                         = [77];
+
+        # 5G NR FR1 bands
+        bands                         = [{{ frequencyBand }}];
         max_pdschReferenceSignalPower = -27;
         max_rxgain                    = 114;
         eNB_instances                 = [0];

--- a/src/templates/du.conf.j2
+++ b/src/templates/du.conf.j2
@@ -68,7 +68,7 @@ gNBs =
 
       # initialDLBWPlocationAndBandwidth: allows the UE to receive the RRC setup including first RB
       # and the number of consecutively used RBs
-      initialDLBWPlocationAndBandwidth                               = {{ initialULBWPlocationAndBandwidth }};
+      initialDLBWPlocationAndBandwidth                               = {{ initialDLBWPlocationAndBandwidth }};
 
       # initialDLBWPsubcarrierSpacing: subcarrierSpacing using numerology
       # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -92,10 +92,10 @@ async def deploy_charm_under_test(ops_test: OpsTest, request):
         application_name=APP_NAME,
         trust=True,
         config={
-            "bandwidth": 20,
+            "bandwidth": 40,
             "frequency-band": 77,
-            "sub-carrier-spacing": 15,
-            "center-frequency": "3500",
+            "sub-carrier-spacing": 30,
+            "center-frequency": "4060",
         },
     )
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -91,6 +91,13 @@ async def deploy_charm_under_test(ops_test: OpsTest, request):
         resources=resources,
         application_name=APP_NAME,
         trust=True,
+        config= {
+            "bandwidth": 20,
+            "frequency-band": 77,
+            "sub-carrier-spacing": 15,
+            "center-frequency": "3500",
+        }
+
     )
 
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -91,13 +91,12 @@ async def deploy_charm_under_test(ops_test: OpsTest, request):
         resources=resources,
         application_name=APP_NAME,
         trust=True,
-        config= {
+        config={
             "bandwidth": 20,
             "frequency-band": 77,
             "sub-carrier-spacing": 15,
             "center-frequency": "3500",
-        }
-
+        },
     )
 
 

--- a/tests/unit/resources/expected_config.conf
+++ b/tests/unit/resources/expected_config.conf
@@ -9,6 +9,7 @@ gNBs =
         gNB_DU_ID = 0xe00;
         gNB_name  =  "whatever-oai-ran-du-k8s-du";
 
+        # tracking_area_code: TAC specified in the CN
         tracking_area_code = 1;
         plmn_list =
         (
@@ -26,107 +27,157 @@ gNBs =
         );
         nr_cellid        = 12345678L;
         min_rxtxtime     = 6;
+
+        # do_CSIRS: 1= active if 2x2 MIMO, otherwise not considered. Suggestion, let it active
         do_CSIRS                                                  = 0;
         do_SRS                                                    = 0;
 
+        # force_256qam_off: disable 256 QAM
         force_256qam_off = 1;
 
     servingCellConfigCommon = (
     {
       physCellId                                                    = 0;
-      #frequencyInfoDL
+      # frequencyInfoDL
 
-      # this is 3924.48 MHz (GSCN: 8141)
-      absoluteFrequencySSB                                             = 661632;
+      # absoluteFrequencySSB: Frequency-domain position of the SSB
+      absoluteFrequencySSB                                             = 633312;
+
+      # dl_frequencyBand: The 5G FR1 band
       dl_frequencyBand                                                 = 77;
 
-      # Absolute Frequency of Point A was calculated like this:
-      # center_frequency - (bandwidth / 2)
-      # the bandwidth in this case is 20 MHz, based on numerology 1
-      # and 51 PRBs.
-      # In this case:
-      # 3925 - (20 / 2)
-      # this is 3915 MHz
-      dl_absoluteFrequencyPointA                                       = 660332;
-      #scs-SpecificCarrierList
+      # dl_absoluteFrequencyPointA: frequency-location of Point A in downlink
+      dl_absoluteFrequencyPointA                                       = 632667;
+
+      # dl_offstToCarrier: Offset in the frequency domain between Point A
       dl_offstToCarrier                                              = 0;
-      # subcarrierSpacing
+
+      # dl_subcarrierSpacing: subcarrierSpacing using numerology
       # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
-      dl_subcarrierSpacing                                           = 1;
+      dl_subcarrierSpacing                                           = 0;
+
+      # dl_carrierBandwidth: number of PRBs
       dl_carrierBandwidth                                            = 106;
-      #initialDownlinkBWP
-      #genericParameters
-      # this is RBstart=27,L=48 (275*(L-1))+RBstart
+
+      # initialDLBWPlocationAndBandwidth: allows the UE to receive the RRC setup including first RB
+      # and the number of consecutively used RBs
       initialDLBWPlocationAndBandwidth                               = 28875;
-      # subcarrierSpacing
+
+      # initialDLBWPsubcarrierSpacing: subcarrierSpacing using numerology
       # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
-      initialDLBWPsubcarrierSpacing                                   = 1;
-      #pdcch-ConfigCommon
+      initialDLBWPsubcarrierSpacing                                   = 0;
+
+      # pdcch-ConfigCommon
+      # initialDLBWPcontrolResourceSetZero:BWP that contains all NR channels that are necessary
+      # to conclude the initial access procedure
       initialDLBWPcontrolResourceSetZero                              = 12;
       initialDLBWPsearchSpaceZero                                     = 0;
 
-      #uplinkConfigCommon
-      #frequencyInfoUL
+      # uplinkConfigCommon
+      # frequencyInfoUL
       ul_frequencyBand                                              = 77;
-      #scs-SpecificCarrierList
+
+      # scs-SpecificCarrierList
+      # ul_offstToCarrier: frequency offset between Point A and the lowest usable subcarrier
+      # in terms of RBs for UL
       ul_offstToCarrier                                             = 0;
-      # subcarrierSpacing
+
+      # ul_subcarrierSpacing: subcarrierSpacing with numerology
       # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
-      ul_subcarrierSpacing                                          = 1;
+      ul_subcarrierSpacing                                          = 0;
+
+      # ul_carrierBandwidth: Number of PRBs
       ul_carrierBandwidth                                           = 106;
+
       pMax                                                          = 20;
-      #initialUplinkBWP
-      #genericParameters
+
+      # initialUplinkBWP
+      # genericParameters
+      # initialULBWPlocationAndBandwidth: allows the UE to receive the RRC setup including
+      # first RB and the number of consecutively used RBs
       initialULBWPlocationAndBandwidth                            = 28875;
-      # subcarrierSpacing
+
+      # initialULBWPsubcarrierSpacing: subcarrierSpacing in numerology
       # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
-      initialULBWPsubcarrierSpacing                               = 1;
-      #rach-ConfigCommon
-      #rach-ConfigGeneric
+      initialULBWPsubcarrierSpacing                               = 0;
+
+      # rach-ConfigCommon
+      # rach-ConfigGeneric
+      # prach_ConfigurationIndex: available set of PRACH occasions for the transmission
+      # of the Random Access Preamble
       prach_ConfigurationIndex                                  = 98;
-      #prach_msg1_FDM
-      #0 = one, 1=two, 2=four, 3=eight
+
+      # prach_msg1_FDM
+      # 0 = one, 1=two, 2=four, 3=eight
       prach_msg1_FDM                                            = 0;
       prach_msg1_FrequencyStart                                 = 0;
       zeroCorrelationZoneConfig                                 = 13;
+
+      # preambleReceivedTargetPower: initial Random Access Preamble power
       preambleReceivedTargetPower                               = -96;
-      #preamblTransMax (0...10) = (3,4,5,6,7,8,10,20,50,100,200)
+
+      # preamblTransMax (0...10) = (3,4,5,6,7,8,10,20,50,100,200)
+      # the maximum number of Random Access Preamble transmission
       preambleTransMax                                          = 6;
-      #powerRampingStep
+
+      # powerRampingStep: the power-ramping factor
       # 0=dB0,1=dB2,2=dB4,3=dB6
       powerRampingStep                                            = 1;
-      #ra_ReponseWindow
-      #1,2,4,8,10,20,40,80
+
+      # ra_ReponseWindow: Msg2 (RAR) window length in number of slots
+      # 1,2,4,8,10,20,40,80
       ra_ResponseWindow                                           = 4;
-      #ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR
-      #1=oneeighth,2=onefourth,3=half,4=one,5=two,6=four,7=eight,8=sixteen
+
+      # ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR
+      # 1=oneeighth,2=onefourth,3=half,4=one,5=two,6=four,7=eight,8=sixteen
       ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR                = 4;
-      #oneHalf (0..15) 4,8,12,16,...60,64
+
+      # ssb_perRACH_OccasionAndCB_PreamblesPerSSB: the number of SSBs mapped to each PRACH occasion
+      # and the number of contention-based Random Access Preambles mapped to each SSB
+      # oneHalf (0..15) 4,8,12,16,...60,64
       ssb_perRACH_OccasionAndCB_PreamblesPerSSB                   = 14;
-      #ra_ContentionResolutionTimer
-      #(0..7) 8,16,24,32,40,48,56,64
+
+      # ra_ContentionResolutionTimer
+      # (0..7) 8,16,24,32,40,48,56,64
       ra_ContentionResolutionTimer                                = 7;
+
+      # rsrp_ThresholdSSB: an RSRP threshold for the selection of the SSB
       rsrp_ThresholdSSB                                           = 19;
-      #prach-RootSequenceIndex_PR
-      #1 = 839, 2 = 139
+
+      # prach-RootSequenceIndex_PR: 5G supports four types of long sequence preambles
+      # with a length of 839 and nine types of short sequence
+      # preambles with a length of 139
+      # 1 = 839, 2 = 139
       prach_RootSequenceIndex_PR                                  = 2;
+
+      # prach_RootSequenceIndex: informs the UE on which sequence to use via SIB2
       prach_RootSequenceIndex                                     = 1;
-      # SCS for msg1, can only be 15 for 30 kHz < 6 GHz, takes precedence over the one derived from prach-ConfigIndex
-      #
+
+      # msg1_SubcarrierSpacing: takes precedence over the one derived from prach-ConfigIndex
+      # SCS for msg1, can only be 15 for 30 kHz < 6 GHz
       msg1_SubcarrierSpacing                                      = 1,
-      # restrictedSetConfig
-      # 0=unrestricted, 1=restricted type A, 2=restricted type B
+
+      # restrictedSetConfig: 0=unrestricted, 1=restricted type A, 2=restricted type B
       restrictedSetConfig                                         = 0,
 
+      # msg3_DeltaPreamble: Power offset between msg3 and RACH preamble transmission in steps of 1dB
       msg3_DeltaPreamble                                          = 1;
+
+      # p0_NominalWithGrant: uplink transmission power on the PUSCH which serves as a reference power level
+      # from which adjustments are made based on various factors like path loss
+      # indicates UE power capability
       p0_NominalWithGrant                                         =-90;
 
-      # pucch-ConfigCommon setup :
-      # pucchGroupHopping
-      # 0 = neither, 1= group hopping, 2=sequence hopping
+      # pucch-ConfigCommon setup
+      # pucchGroupHopping: 0 = neither, 1= group hopping, 2=sequence hopping
       pucchGroupHopping                                           = 0;
+
+      # hoppingId: Gets or sets hopping ID for PUCCH Format 1 or 4 configuration
       hoppingId                                                   = 40;
+
+      # p0_nominal: the power for a Pucch transmission
       p0_nominal                                                  = -90;
+
       # ssb_PositionsInBurs_BitmapPR
       # 1=short, 2=medium, 3=long
       ssb_PositionsInBurst_Bitmap                                   = 1;
@@ -139,24 +190,32 @@ gNBs =
       # 0 = pos2, 1 = pos3
       dmrs_TypeA_Position                                           = 0;
 
-      # subcarrierSpacing
+      # subcarrierSpacing with numerology
       # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
-      subcarrierSpacing                                             = 1;
+      subcarrierSpacing                                             = 0;
 
-
-      #tdd-UL-DL-ConfigurationCommon
-      # subcarrierSpacing
+      # tdd-UL-DL-ConfigurationCommon
+      # subcarrierSpacing with numerology
       # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
-      referenceSubcarrierSpacing                                    = 1;
-      # pattern1
-      # dl_UL_TransmissionPeriodicity
+      referenceSubcarrierSpacing                                    = 0;
+
+      # dl_UL_TransmissionPeriodicity: periodicity indexes
       # 0=ms0p5, 1=ms0p625, 2=ms1, 3=ms1p25, 4=ms2, 5=ms2p5, 6=ms5, 7=ms10
       dl_UL_TransmissionPeriodicity                                 = 6;
+
+      # DL slots
       nrofDownlinkSlots                                             = 7;
+
+      # DL symbols in mixed slots
       nrofDownlinkSymbols                                           = 6;
+
+      # UL slots
       nrofUplinkSlots                                               = 2;
+
+      # UL symbols in mixed slots
       nrofUplinkSymbols                                             = 4;
 
+      # ssPBCH_BlockPower: the power at which gNB transmit the reference signal (SSB block power)
       ssPBCH_BlockPower                                             = -25;
   }
   );
@@ -204,11 +263,22 @@ L1s =
 RUs =
 (
     {
+        # local_rf: indicates the monolithic connection to the SDR
         local_rf                      = "yes"
+
+        # nb_tx: 1 means SISO, 2 means MIMO
         nb_tx                         = 1
+
+        # nb_rx: 1 means SISO, 2 means MIMO
         nb_rx                         = 1
+
+        # att_tx: ranges 6-10 if the UE is close to the B210 antennas. Leave 0 otherwise
         att_tx                        = 12;
+
+        # att_rx: ranges 6-10 if the UE is close to the B210 antennas. Leave 0 otherwise
         att_rx                        = 12;
+
+        # 5G NR FR1 bands
         bands                         = [77];
         max_pdschReferenceSignalPower = -27;
         max_rxgain                    = 114;

--- a/tests/unit/resources/expected_multiple_plmns_config.conf
+++ b/tests/unit/resources/expected_multiple_plmns_config.conf
@@ -9,6 +9,7 @@ gNBs =
         gNB_DU_ID = 0xe00;
         gNB_name  =  "whatever-oai-ran-du-k8s-du";
 
+        # tracking_area_code: TAC specified in the CN
         tracking_area_code = 12;
         plmn_list =
         (
@@ -38,107 +39,157 @@ gNBs =
         );
         nr_cellid        = 12345678L;
         min_rxtxtime     = 6;
+
+        # do_CSIRS: 1= active if 2x2 MIMO, otherwise not considered. Suggestion, let it active
         do_CSIRS                                                  = 0;
         do_SRS                                                    = 0;
 
+        # force_256qam_off: disable 256 QAM
         force_256qam_off = 1;
 
     servingCellConfigCommon = (
     {
       physCellId                                                    = 0;
-      #frequencyInfoDL
+      # frequencyInfoDL
 
-      # this is 3924.48 MHz (GSCN: 8141)
-      absoluteFrequencySSB                                             = 661632;
+      # absoluteFrequencySSB: Frequency-domain position of the SSB
+      absoluteFrequencySSB                                             = 633312;
+
+      # dl_frequencyBand: The 5G FR1 band
       dl_frequencyBand                                                 = 77;
 
-      # Absolute Frequency of Point A was calculated like this:
-      # center_frequency - (bandwidth / 2)
-      # the bandwidth in this case is 20 MHz, based on numerology 1
-      # and 51 PRBs.
-      # In this case:
-      # 3925 - (20 / 2)
-      # this is 3915 MHz
-      dl_absoluteFrequencyPointA                                       = 660332;
-      #scs-SpecificCarrierList
+      # dl_absoluteFrequencyPointA: frequency-location of Point A in downlink
+      dl_absoluteFrequencyPointA                                       = 632667;
+
+      # dl_offstToCarrier: Offset in the frequency domain between Point A
       dl_offstToCarrier                                              = 0;
-      # subcarrierSpacing
+
+      # dl_subcarrierSpacing: subcarrierSpacing using numerology
       # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
-      dl_subcarrierSpacing                                           = 1;
+      dl_subcarrierSpacing                                           = 0;
+
+      # dl_carrierBandwidth: number of PRBs
       dl_carrierBandwidth                                            = 106;
-      #initialDownlinkBWP
-      #genericParameters
-      # this is RBstart=27,L=48 (275*(L-1))+RBstart
+
+      # initialDLBWPlocationAndBandwidth: allows the UE to receive the RRC setup including first RB
+      # and the number of consecutively used RBs
       initialDLBWPlocationAndBandwidth                               = 28875;
-      # subcarrierSpacing
+
+      # initialDLBWPsubcarrierSpacing: subcarrierSpacing using numerology
       # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
-      initialDLBWPsubcarrierSpacing                                   = 1;
-      #pdcch-ConfigCommon
+      initialDLBWPsubcarrierSpacing                                   = 0;
+
+      # pdcch-ConfigCommon
+      # initialDLBWPcontrolResourceSetZero:BWP that contains all NR channels that are necessary
+      # to conclude the initial access procedure
       initialDLBWPcontrolResourceSetZero                              = 12;
       initialDLBWPsearchSpaceZero                                     = 0;
 
-      #uplinkConfigCommon
-      #frequencyInfoUL
+      # uplinkConfigCommon
+      # frequencyInfoUL
       ul_frequencyBand                                              = 77;
-      #scs-SpecificCarrierList
+
+      # scs-SpecificCarrierList
+      # ul_offstToCarrier: frequency offset between Point A and the lowest usable subcarrier
+      # in terms of RBs for UL
       ul_offstToCarrier                                             = 0;
-      # subcarrierSpacing
+
+      # ul_subcarrierSpacing: subcarrierSpacing with numerology
       # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
-      ul_subcarrierSpacing                                          = 1;
+      ul_subcarrierSpacing                                          = 0;
+
+      # ul_carrierBandwidth: Number of PRBs
       ul_carrierBandwidth                                           = 106;
+
       pMax                                                          = 20;
-      #initialUplinkBWP
-      #genericParameters
+
+      # initialUplinkBWP
+      # genericParameters
+      # initialULBWPlocationAndBandwidth: allows the UE to receive the RRC setup including
+      # first RB and the number of consecutively used RBs
       initialULBWPlocationAndBandwidth                            = 28875;
-      # subcarrierSpacing
+
+      # initialULBWPsubcarrierSpacing: subcarrierSpacing in numerology
       # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
-      initialULBWPsubcarrierSpacing                               = 1;
-      #rach-ConfigCommon
-      #rach-ConfigGeneric
+      initialULBWPsubcarrierSpacing                               = 0;
+
+      # rach-ConfigCommon
+      # rach-ConfigGeneric
+      # prach_ConfigurationIndex: available set of PRACH occasions for the transmission
+      # of the Random Access Preamble
       prach_ConfigurationIndex                                  = 98;
-      #prach_msg1_FDM
-      #0 = one, 1=two, 2=four, 3=eight
+
+      # prach_msg1_FDM
+      # 0 = one, 1=two, 2=four, 3=eight
       prach_msg1_FDM                                            = 0;
       prach_msg1_FrequencyStart                                 = 0;
       zeroCorrelationZoneConfig                                 = 13;
+
+      # preambleReceivedTargetPower: initial Random Access Preamble power
       preambleReceivedTargetPower                               = -96;
-      #preamblTransMax (0...10) = (3,4,5,6,7,8,10,20,50,100,200)
+
+      # preamblTransMax (0...10) = (3,4,5,6,7,8,10,20,50,100,200)
+      # the maximum number of Random Access Preamble transmission
       preambleTransMax                                          = 6;
-      #powerRampingStep
+
+      # powerRampingStep: the power-ramping factor
       # 0=dB0,1=dB2,2=dB4,3=dB6
       powerRampingStep                                            = 1;
-      #ra_ReponseWindow
-      #1,2,4,8,10,20,40,80
+
+      # ra_ReponseWindow: Msg2 (RAR) window length in number of slots
+      # 1,2,4,8,10,20,40,80
       ra_ResponseWindow                                           = 4;
-      #ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR
-      #1=oneeighth,2=onefourth,3=half,4=one,5=two,6=four,7=eight,8=sixteen
+
+      # ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR
+      # 1=oneeighth,2=onefourth,3=half,4=one,5=two,6=four,7=eight,8=sixteen
       ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR                = 4;
-      #oneHalf (0..15) 4,8,12,16,...60,64
+
+      # ssb_perRACH_OccasionAndCB_PreamblesPerSSB: the number of SSBs mapped to each PRACH occasion
+      # and the number of contention-based Random Access Preambles mapped to each SSB
+      # oneHalf (0..15) 4,8,12,16,...60,64
       ssb_perRACH_OccasionAndCB_PreamblesPerSSB                   = 14;
-      #ra_ContentionResolutionTimer
-      #(0..7) 8,16,24,32,40,48,56,64
+
+      # ra_ContentionResolutionTimer
+      # (0..7) 8,16,24,32,40,48,56,64
       ra_ContentionResolutionTimer                                = 7;
+
+      # rsrp_ThresholdSSB: an RSRP threshold for the selection of the SSB
       rsrp_ThresholdSSB                                           = 19;
-      #prach-RootSequenceIndex_PR
-      #1 = 839, 2 = 139
+
+      # prach-RootSequenceIndex_PR: 5G supports four types of long sequence preambles
+      # with a length of 839 and nine types of short sequence
+      # preambles with a length of 139
+      # 1 = 839, 2 = 139
       prach_RootSequenceIndex_PR                                  = 2;
+
+      # prach_RootSequenceIndex: informs the UE on which sequence to use via SIB2
       prach_RootSequenceIndex                                     = 1;
-      # SCS for msg1, can only be 15 for 30 kHz < 6 GHz, takes precedence over the one derived from prach-ConfigIndex
-      #
+
+      # msg1_SubcarrierSpacing: takes precedence over the one derived from prach-ConfigIndex
+      # SCS for msg1, can only be 15 for 30 kHz < 6 GHz
       msg1_SubcarrierSpacing                                      = 1,
-      # restrictedSetConfig
-      # 0=unrestricted, 1=restricted type A, 2=restricted type B
+
+      # restrictedSetConfig: 0=unrestricted, 1=restricted type A, 2=restricted type B
       restrictedSetConfig                                         = 0,
 
+      # msg3_DeltaPreamble: Power offset between msg3 and RACH preamble transmission in steps of 1dB
       msg3_DeltaPreamble                                          = 1;
+
+      # p0_NominalWithGrant: uplink transmission power on the PUSCH which serves as a reference power level
+      # from which adjustments are made based on various factors like path loss
+      # indicates UE power capability
       p0_NominalWithGrant                                         =-90;
 
-      # pucch-ConfigCommon setup :
-      # pucchGroupHopping
-      # 0 = neither, 1= group hopping, 2=sequence hopping
+      # pucch-ConfigCommon setup
+      # pucchGroupHopping: 0 = neither, 1= group hopping, 2=sequence hopping
       pucchGroupHopping                                           = 0;
+
+      # hoppingId: Gets or sets hopping ID for PUCCH Format 1 or 4 configuration
       hoppingId                                                   = 40;
+
+      # p0_nominal: the power for a Pucch transmission
       p0_nominal                                                  = -90;
+
       # ssb_PositionsInBurs_BitmapPR
       # 1=short, 2=medium, 3=long
       ssb_PositionsInBurst_Bitmap                                   = 1;
@@ -151,24 +202,32 @@ gNBs =
       # 0 = pos2, 1 = pos3
       dmrs_TypeA_Position                                           = 0;
 
-      # subcarrierSpacing
+      # subcarrierSpacing with numerology
       # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
-      subcarrierSpacing                                             = 1;
+      subcarrierSpacing                                             = 0;
 
-
-      #tdd-UL-DL-ConfigurationCommon
-      # subcarrierSpacing
+      # tdd-UL-DL-ConfigurationCommon
+      # subcarrierSpacing with numerology
       # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
-      referenceSubcarrierSpacing                                    = 1;
-      # pattern1
-      # dl_UL_TransmissionPeriodicity
+      referenceSubcarrierSpacing                                    = 0;
+
+      # dl_UL_TransmissionPeriodicity: periodicity indexes
       # 0=ms0p5, 1=ms0p625, 2=ms1, 3=ms1p25, 4=ms2, 5=ms2p5, 6=ms5, 7=ms10
       dl_UL_TransmissionPeriodicity                                 = 6;
+
+      # DL slots
       nrofDownlinkSlots                                             = 7;
+
+      # DL symbols in mixed slots
       nrofDownlinkSymbols                                           = 6;
+
+      # UL slots
       nrofUplinkSlots                                               = 2;
+
+      # UL symbols in mixed slots
       nrofUplinkSymbols                                             = 4;
 
+      # ssPBCH_BlockPower: the power at which gNB transmit the reference signal (SSB block power)
       ssPBCH_BlockPower                                             = -25;
   }
   );
@@ -216,11 +275,22 @@ L1s =
 RUs =
 (
     {
+        # local_rf: indicates the monolithic connection to the SDR
         local_rf                      = "yes"
+
+        # nb_tx: 1 means SISO, 2 means MIMO
         nb_tx                         = 1
+
+        # nb_rx: 1 means SISO, 2 means MIMO
         nb_rx                         = 1
+
+        # att_tx: ranges 6-10 if the UE is close to the B210 antennas. Leave 0 otherwise
         att_tx                        = 12;
+
+        # att_rx: ranges 6-10 if the UE is close to the B210 antennas. Leave 0 otherwise
         att_rx                        = 12;
+
+        # 5G NR FR1 bands
         bands                         = [77];
         max_pdschReferenceSignalPower = -27;
         max_rxgain                    = 114;

--- a/tests/unit/resources/expected_rfsim_mode_config.conf
+++ b/tests/unit/resources/expected_rfsim_mode_config.conf
@@ -9,6 +9,7 @@ gNBs =
         gNB_DU_ID = 0xe00;
         gNB_name  =  "whatever-oai-ran-du-k8s-du";
 
+        # tracking_area_code: TAC specified in the CN
         tracking_area_code = 1;
         plmn_list =
         (
@@ -26,107 +27,157 @@ gNBs =
         );
         nr_cellid        = 12345678L;
         min_rxtxtime     = 6;
+
+        # do_CSIRS: 1= active if 2x2 MIMO, otherwise not considered. Suggestion, let it active
         do_CSIRS                                                  = 0;
         do_SRS                                                    = 0;
 
+        # force_256qam_off: disable 256 QAM
         force_256qam_off = 1;
 
     servingCellConfigCommon = (
     {
       physCellId                                                    = 0;
-      #frequencyInfoDL
+      # frequencyInfoDL
 
-      # this is 3924.48 MHz (GSCN: 8141)
-      absoluteFrequencySSB                                             = 661632;
+      # absoluteFrequencySSB: Frequency-domain position of the SSB
+      absoluteFrequencySSB                                             = 633312;
+
+      # dl_frequencyBand: The 5G FR1 band
       dl_frequencyBand                                                 = 77;
 
-      # Absolute Frequency of Point A was calculated like this:
-      # center_frequency - (bandwidth / 2)
-      # the bandwidth in this case is 20 MHz, based on numerology 1
-      # and 51 PRBs.
-      # In this case:
-      # 3925 - (20 / 2)
-      # this is 3915 MHz
-      dl_absoluteFrequencyPointA                                       = 660332;
-      #scs-SpecificCarrierList
+      # dl_absoluteFrequencyPointA: frequency-location of Point A in downlink
+      dl_absoluteFrequencyPointA                                       = 632667;
+
+      # dl_offstToCarrier: Offset in the frequency domain between Point A
       dl_offstToCarrier                                              = 0;
-      # subcarrierSpacing
+
+      # dl_subcarrierSpacing: subcarrierSpacing using numerology
       # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
-      dl_subcarrierSpacing                                           = 1;
+      dl_subcarrierSpacing                                           = 0;
+
+      # dl_carrierBandwidth: number of PRBs
       dl_carrierBandwidth                                            = 106;
-      #initialDownlinkBWP
-      #genericParameters
-      # this is RBstart=27,L=48 (275*(L-1))+RBstart
+
+      # initialDLBWPlocationAndBandwidth: allows the UE to receive the RRC setup including first RB
+      # and the number of consecutively used RBs
       initialDLBWPlocationAndBandwidth                               = 28875;
-      # subcarrierSpacing
+
+      # initialDLBWPsubcarrierSpacing: subcarrierSpacing using numerology
       # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
-      initialDLBWPsubcarrierSpacing                                   = 1;
-      #pdcch-ConfigCommon
+      initialDLBWPsubcarrierSpacing                                   = 0;
+
+      # pdcch-ConfigCommon
+      # initialDLBWPcontrolResourceSetZero:BWP that contains all NR channels that are necessary
+      # to conclude the initial access procedure
       initialDLBWPcontrolResourceSetZero                              = 12;
       initialDLBWPsearchSpaceZero                                     = 0;
 
-      #uplinkConfigCommon
-      #frequencyInfoUL
+      # uplinkConfigCommon
+      # frequencyInfoUL
       ul_frequencyBand                                              = 77;
-      #scs-SpecificCarrierList
+
+      # scs-SpecificCarrierList
+      # ul_offstToCarrier: frequency offset between Point A and the lowest usable subcarrier
+      # in terms of RBs for UL
       ul_offstToCarrier                                             = 0;
-      # subcarrierSpacing
+
+      # ul_subcarrierSpacing: subcarrierSpacing with numerology
       # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
-      ul_subcarrierSpacing                                          = 1;
+      ul_subcarrierSpacing                                          = 0;
+
+      # ul_carrierBandwidth: Number of PRBs
       ul_carrierBandwidth                                           = 106;
+
       pMax                                                          = 20;
-      #initialUplinkBWP
-      #genericParameters
+
+      # initialUplinkBWP
+      # genericParameters
+      # initialULBWPlocationAndBandwidth: allows the UE to receive the RRC setup including
+      # first RB and the number of consecutively used RBs
       initialULBWPlocationAndBandwidth                            = 28875;
-      # subcarrierSpacing
+
+      # initialULBWPsubcarrierSpacing: subcarrierSpacing in numerology
       # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
-      initialULBWPsubcarrierSpacing                               = 1;
-      #rach-ConfigCommon
-      #rach-ConfigGeneric
+      initialULBWPsubcarrierSpacing                               = 0;
+
+      # rach-ConfigCommon
+      # rach-ConfigGeneric
+      # prach_ConfigurationIndex: available set of PRACH occasions for the transmission
+      # of the Random Access Preamble
       prach_ConfigurationIndex                                  = 98;
-      #prach_msg1_FDM
-      #0 = one, 1=two, 2=four, 3=eight
+
+      # prach_msg1_FDM
+      # 0 = one, 1=two, 2=four, 3=eight
       prach_msg1_FDM                                            = 0;
       prach_msg1_FrequencyStart                                 = 0;
       zeroCorrelationZoneConfig                                 = 13;
+
+      # preambleReceivedTargetPower: initial Random Access Preamble power
       preambleReceivedTargetPower                               = -96;
-      #preamblTransMax (0...10) = (3,4,5,6,7,8,10,20,50,100,200)
+
+      # preamblTransMax (0...10) = (3,4,5,6,7,8,10,20,50,100,200)
+      # the maximum number of Random Access Preamble transmission
       preambleTransMax                                          = 6;
-      #powerRampingStep
+
+      # powerRampingStep: the power-ramping factor
       # 0=dB0,1=dB2,2=dB4,3=dB6
       powerRampingStep                                            = 1;
-      #ra_ReponseWindow
-      #1,2,4,8,10,20,40,80
+
+      # ra_ReponseWindow: Msg2 (RAR) window length in number of slots
+      # 1,2,4,8,10,20,40,80
       ra_ResponseWindow                                           = 4;
-      #ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR
-      #1=oneeighth,2=onefourth,3=half,4=one,5=two,6=four,7=eight,8=sixteen
+
+      # ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR
+      # 1=oneeighth,2=onefourth,3=half,4=one,5=two,6=four,7=eight,8=sixteen
       ssb_perRACH_OccasionAndCB_PreamblesPerSSB_PR                = 4;
-      #oneHalf (0..15) 4,8,12,16,...60,64
+
+      # ssb_perRACH_OccasionAndCB_PreamblesPerSSB: the number of SSBs mapped to each PRACH occasion
+      # and the number of contention-based Random Access Preambles mapped to each SSB
+      # oneHalf (0..15) 4,8,12,16,...60,64
       ssb_perRACH_OccasionAndCB_PreamblesPerSSB                   = 14;
-      #ra_ContentionResolutionTimer
-      #(0..7) 8,16,24,32,40,48,56,64
+
+      # ra_ContentionResolutionTimer
+      # (0..7) 8,16,24,32,40,48,56,64
       ra_ContentionResolutionTimer                                = 7;
+
+      # rsrp_ThresholdSSB: an RSRP threshold for the selection of the SSB
       rsrp_ThresholdSSB                                           = 19;
-      #prach-RootSequenceIndex_PR
-      #1 = 839, 2 = 139
+
+      # prach-RootSequenceIndex_PR: 5G supports four types of long sequence preambles
+      # with a length of 839 and nine types of short sequence
+      # preambles with a length of 139
+      # 1 = 839, 2 = 139
       prach_RootSequenceIndex_PR                                  = 2;
+
+      # prach_RootSequenceIndex: informs the UE on which sequence to use via SIB2
       prach_RootSequenceIndex                                     = 1;
-      # SCS for msg1, can only be 15 for 30 kHz < 6 GHz, takes precedence over the one derived from prach-ConfigIndex
-      #
+
+      # msg1_SubcarrierSpacing: takes precedence over the one derived from prach-ConfigIndex
+      # SCS for msg1, can only be 15 for 30 kHz < 6 GHz
       msg1_SubcarrierSpacing                                      = 1,
-      # restrictedSetConfig
-      # 0=unrestricted, 1=restricted type A, 2=restricted type B
+
+      # restrictedSetConfig: 0=unrestricted, 1=restricted type A, 2=restricted type B
       restrictedSetConfig                                         = 0,
 
+      # msg3_DeltaPreamble: Power offset between msg3 and RACH preamble transmission in steps of 1dB
       msg3_DeltaPreamble                                          = 1;
+
+      # p0_NominalWithGrant: uplink transmission power on the PUSCH which serves as a reference power level
+      # from which adjustments are made based on various factors like path loss
+      # indicates UE power capability
       p0_NominalWithGrant                                         =-90;
 
-      # pucch-ConfigCommon setup :
-      # pucchGroupHopping
-      # 0 = neither, 1= group hopping, 2=sequence hopping
+      # pucch-ConfigCommon setup
+      # pucchGroupHopping: 0 = neither, 1= group hopping, 2=sequence hopping
       pucchGroupHopping                                           = 0;
+
+      # hoppingId: Gets or sets hopping ID for PUCCH Format 1 or 4 configuration
       hoppingId                                                   = 40;
+
+      # p0_nominal: the power for a Pucch transmission
       p0_nominal                                                  = -90;
+
       # ssb_PositionsInBurs_BitmapPR
       # 1=short, 2=medium, 3=long
       ssb_PositionsInBurst_Bitmap                                   = 1;
@@ -139,24 +190,32 @@ gNBs =
       # 0 = pos2, 1 = pos3
       dmrs_TypeA_Position                                           = 0;
 
-      # subcarrierSpacing
+      # subcarrierSpacing with numerology
       # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
-      subcarrierSpacing                                             = 1;
+      subcarrierSpacing                                             = 0;
 
-
-      #tdd-UL-DL-ConfigurationCommon
-      # subcarrierSpacing
+      # tdd-UL-DL-ConfigurationCommon
+      # subcarrierSpacing with numerology
       # 0=kHz15, 1=kHz30, 2=kHz60, 3=kHz120
-      referenceSubcarrierSpacing                                    = 1;
-      # pattern1
-      # dl_UL_TransmissionPeriodicity
+      referenceSubcarrierSpacing                                    = 0;
+
+      # dl_UL_TransmissionPeriodicity: periodicity indexes
       # 0=ms0p5, 1=ms0p625, 2=ms1, 3=ms1p25, 4=ms2, 5=ms2p5, 6=ms5, 7=ms10
       dl_UL_TransmissionPeriodicity                                 = 6;
+
+      # DL slots
       nrofDownlinkSlots                                             = 7;
+
+      # DL symbols in mixed slots
       nrofDownlinkSymbols                                           = 6;
+
+      # UL slots
       nrofUplinkSlots                                               = 2;
+
+      # UL symbols in mixed slots
       nrofUplinkSymbols                                             = 4;
 
+      # ssPBCH_BlockPower: the power at which gNB transmit the reference signal (SSB block power)
       ssPBCH_BlockPower                                             = -25;
   }
   );
@@ -204,11 +263,22 @@ L1s =
 RUs =
 (
     {
+        # local_rf: indicates the monolithic connection to the SDR
         local_rf                      = "yes"
+
+        # nb_tx: 1 means SISO, 2 means MIMO
         nb_tx                         = 1
+
+        # nb_rx: 1 means SISO, 2 means MIMO
         nb_rx                         = 1
+
+        # att_tx: ranges 6-10 if the UE is close to the B210 antennas. Leave 0 otherwise
         att_tx                        = 12;
+
+        # att_rx: ranges 6-10 if the UE is close to the B210 antennas. Leave 0 otherwise
         att_rx                        = 12;
+
+        # 5G NR FR1 bands
         bands                         = [77];
         max_pdschReferenceSignalPower = -27;
         max_rxgain                    = 114;

--- a/tests/unit/test_absolute_freq_point_a.py
+++ b/tests/unit/test_absolute_freq_point_a.py
@@ -14,110 +14,140 @@ from src.du_parameters.frequency import ARFCN, Frequency
 
 class TestDLAbsoluteFrequencyPointA:
     @pytest.mark.parametrize(
-        "center_freq, bandwidth, expected_arfcn_value",
-        [
-            (Frequency.from_mhz(1000), Frequency.from_mhz("20.43"), 197957),
-            (Frequency.from_mhz("700.3"), Frequency.from_mhz(10), 139060),
-            (Frequency.from_mhz(3500), Frequency.from_mhz(100), 630000),
-            (Frequency.from_mhz(3925), Frequency.from_mhz(20), 661000),
-            (Frequency.from_mhz(25000), Frequency.from_mhz(20), 2029000),
-            (Frequency.from_mhz("24000.523"), Frequency.from_mhz(20), 1999368),
-        ],
-    )
-    def test_get_dl_absolute_frequency_point_a_when_valid_inputs_given_then_return_expected_values(  # noqa: E501
-        self, center_freq, bandwidth, expected_arfcn_value
-    ):
-        result = get_dl_absolute_frequency_point_a(center_freq, bandwidth)
-        assert isinstance(result, ARFCN)
-        assert result._channel == expected_arfcn_value
-
-    @pytest.mark.parametrize(
-        "center_freq, bandwidth, expected_lowest_freq",
+        "center_freq, bandwidth, subcarrier_spacing, expected_arfcn_value",
         [
             (
                 Frequency.from_mhz(1000),
                 Frequency.from_mhz("20.43"),
-                Frequency(str(989784999.9999999681676854379)),
+                Frequency.from_khz(15),
+                197958,
+            ),
+            (Frequency.from_mhz("700.3"), Frequency.from_mhz(10), Frequency.from_khz(15), 139059),
+            (Frequency.from_mhz(4060), Frequency.from_mhz(40), Frequency.from_khz(30), 669334),
+            (Frequency.from_mhz(3925), Frequency.from_mhz(20), Frequency.from_khz(15), 661000),
+            (Frequency.from_mhz(25000), Frequency.from_mhz(20), Frequency.from_khz(60), 2029000),
+            (
+                Frequency.from_mhz("24000.523"),
+                Frequency.from_mhz(20),
+                Frequency.from_khz(30),
+                1999368,
+            ),
+        ],
+    )
+    def test_get_dl_absolute_frequency_point_a_when_valid_inputs_given_then_return_expected_values(  # noqa: E501
+        self, center_freq, bandwidth, subcarrier_spacing, expected_arfcn_value
+    ):
+        result = get_dl_absolute_frequency_point_a(center_freq, bandwidth, subcarrier_spacing)
+        assert isinstance(result, ARFCN)
+        assert result._channel == expected_arfcn_value
+
+    @pytest.mark.parametrize(
+        "center_freq, bandwidth, sub_carrier_spacing, expected_lowest_freq",
+        [
+            (
+                Frequency.from_mhz(1000),
+                Frequency.from_mhz("20.43"),
+                Frequency.from_khz(30),
+                Frequency.from_khz(989790),
             ),
             (
                 Frequency.from_mhz("700.3"),
                 Frequency.from_mhz(10),
-                Frequency(str(695299999.9999999545252649114)),
+                Frequency.from_khz(30),
+                Frequency.from_khz(695310),
             ),
-            (Frequency.from_mhz(3500), Frequency.from_mhz(100), Frequency.from_mhz(3450)),
-            (Frequency.from_mhz(3925), Frequency.from_mhz(20), Frequency.from_mhz(3915)),
+            (
+                Frequency.from_mhz(3500),
+                Frequency.from_mhz(100),
+                Frequency.from_khz(30),
+                Frequency.from_mhz(3450),
+            ),
+            (
+                Frequency.from_mhz(3925),
+                Frequency.from_mhz(20),
+                Frequency.from_khz(30),
+                Frequency.from_mhz(3915),
+            ),
         ],
     )
-    def test_get_dl_absolute_frequency_point_a_when_valid_inputs_given_then_get_expected_lowest_freq_calculation(  # noqa: E501
-        self, center_freq, bandwidth, expected_lowest_freq
+    def test_get_dl_absolute_frequency_point_a_when_valid_inputs_given_then_get_aligned_lowest_freq_calculation(  # noqa: E501
+        self, center_freq, bandwidth, sub_carrier_spacing, expected_lowest_freq
     ):
         actual_lowest_freq = center_freq - (bandwidth / CONFIG_CONSTANT_TWO)
-        assert actual_lowest_freq == expected_lowest_freq
-        result = get_dl_absolute_frequency_point_a(center_freq, bandwidth)
+        aligned_lowes_freq = round(actual_lowest_freq / sub_carrier_spacing) * sub_carrier_spacing
+        assert expected_lowest_freq == aligned_lowes_freq
+        result = get_dl_absolute_frequency_point_a(center_freq, bandwidth, sub_carrier_spacing)
         assert isinstance(result, ARFCN)
 
     @pytest.mark.parametrize(
-        "center_freq, bandwidth, expected_exception, expected_msg",
+        "center_freq, bandwidth, sub_carrier_spacing, expected_exception, expected_msg",
         [
             (
                 "invalid",
                 Frequency.from_mhz(20),
+                Frequency.from_khz(30),
                 DLAbsoluteFrequencyPointAError,
                 "Unsupported type for subtraction: <class 'str'>",
             ),
             (
                 Frequency.from_mhz(1000),
                 "20",
+                Frequency.from_khz(30),
                 DLAbsoluteFrequencyPointAError,
                 "unsupported operand type(s) for /: 'str' and 'decimal.Decimal'",
             ),
             (
                 None,
                 Frequency.from_mhz(20),
+                Frequency.from_khz(30),
                 DLAbsoluteFrequencyPointAError,
                 "Unsupported type for subtraction: <class 'NoneType'>",
             ),
         ],
     )
     def test_get_dl_absolute_frequency_point_a_when_invalid_inputs_given_then_raise_error(
-        self, center_freq, bandwidth, expected_exception, expected_msg
+        self, center_freq, bandwidth, sub_carrier_spacing, expected_exception, expected_msg
     ):
         with pytest.raises(expected_exception) as err:
-            get_dl_absolute_frequency_point_a(center_freq, bandwidth)
+            get_dl_absolute_frequency_point_a(center_freq, bandwidth, sub_carrier_spacing)
         assert expected_msg in str(err.value)
 
     @pytest.mark.parametrize(
-        "center_freq, bandwidth, expected_exception, expected_msg",
+        "center_freq, bandwidth, sub_carrier_spacing, expected_exception, expected_msg",
         [
             (
                 Frequency.from_mhz(392533333),
                 Frequency.from_mhz(20),
+                Frequency.from_khz(30),
                 DLAbsoluteFrequencyPointAError,
                 "No frequency range found for frequency 392533323000000",
             ),
             (
                 Frequency.from_mhz(-1000),
                 Frequency.from_mhz(50),
+                Frequency.from_khz(30),
                 DLAbsoluteFrequencyPointAError,
-                "No frequency range found for frequency -1025000000",
+                "No frequency range found for frequency -1025010000",
             ),
             (
                 None,
                 Frequency.from_mhz(20),
+                Frequency.from_khz(30),
                 DLAbsoluteFrequencyPointAError,
                 "Unsupported type for subtraction: <class 'NoneType'>",
             ),
             (
                 "24000.523",
                 Frequency.from_mhz(20),
+                Frequency.from_khz(30),
                 DLAbsoluteFrequencyPointAError,
-                "No frequency range found for frequency -9975999.477",
+                "No frequency range found for frequency -9990000",
             ),
         ],
     )
     def test_get_dl_absolute_frequency_point_a_when_invalid_values_provided_then_dl_absolute_frequency_point_a_error_raised(  # noqa: E501
-        self, center_freq, bandwidth, expected_exception, expected_msg
+        self, center_freq, bandwidth, sub_carrier_spacing, expected_exception, expected_msg
     ):
         with pytest.raises(expected_exception) as err:
-            get_dl_absolute_frequency_point_a(center_freq, bandwidth)
+            get_dl_absolute_frequency_point_a(center_freq, bandwidth, sub_carrier_spacing)
         assert expected_msg in str(err.value)

--- a/tests/unit/test_absolute_freq_point_a.py
+++ b/tests/unit/test_absolute_freq_point_a.py
@@ -4,12 +4,13 @@
 
 import pytest
 
-from src.du_parameters.dl_absolute_freq_point_a import (
+from src.du_parameters import (
+    ARFCN,
     CONFIG_CONSTANT_TWO,
     DLAbsoluteFrequencyPointAError,
+    Frequency,
     get_dl_absolute_frequency_point_a,
 )
-from src.du_parameters.frequency import ARFCN, Frequency
 
 
 class TestDLAbsoluteFrequencyPointA:
@@ -22,7 +23,7 @@ class TestDLAbsoluteFrequencyPointA:
                 Frequency.from_khz(15),
                 197958,
             ),
-            (Frequency.from_mhz("700.3"), Frequency.from_mhz(10), Frequency.from_khz(15), 139059),
+            (Frequency.from_mhz("700.3"), Frequency.from_mhz(10), Frequency.from_khz(15), 139062),
             (Frequency.from_mhz(4060), Frequency.from_mhz(40), Frequency.from_khz(30), 669334),
             (Frequency.from_mhz(3925), Frequency.from_mhz(20), Frequency.from_khz(15), 661000),
             (Frequency.from_mhz(25000), Frequency.from_mhz(20), Frequency.from_khz(60), 2029000),
@@ -30,7 +31,7 @@ class TestDLAbsoluteFrequencyPointA:
                 Frequency.from_mhz("24000.523"),
                 Frequency.from_mhz(20),
                 Frequency.from_khz(30),
-                1999368,
+                1999370,
             ),
         ],
     )
@@ -127,7 +128,7 @@ class TestDLAbsoluteFrequencyPointA:
                 Frequency.from_mhz(50),
                 Frequency.from_khz(30),
                 DLAbsoluteFrequencyPointAError,
-                "No frequency range found for frequency -1025010000",
+                "No frequency range found for frequency -1024980000",
             ),
             (
                 None,
@@ -141,7 +142,7 @@ class TestDLAbsoluteFrequencyPointA:
                 Frequency.from_mhz(20),
                 Frequency.from_khz(30),
                 DLAbsoluteFrequencyPointAError,
-                "No frequency range found for frequency -9990000",
+                "No frequency range found for frequency -9960000",
             ),
         ],
     )

--- a/tests/unit/test_absolute_freq_ssb.py
+++ b/tests/unit/test_absolute_freq_ssb.py
@@ -5,11 +5,12 @@
 
 import pytest
 
-from src.du_parameters.absolute_freq_ssb import (
+from src.du_parameters import (
+    ARFCN,
     AbsoluteFrequencySSBError,
+    Frequency,
     get_absolute_frequency_ssb,
 )
-from src.du_parameters.frequency import ARFCN, Frequency
 
 
 class TestAbsoluteFrequencySSB:

--- a/tests/unit/test_carrier_bandwidth.py
+++ b/tests/unit/test_carrier_bandwidth.py
@@ -4,9 +4,12 @@
 
 import pytest
 
-from src.du_parameters.carrier_bandwidth import get_carrier_bandwidth
-from src.du_parameters.frequency import Frequency
-from src.du_parameters.guard_band import GuardBandError, get_minimum_guard_band
+from src.du_parameters import (
+    Frequency,
+    GuardBandError,
+    get_carrier_bandwidth,
+    get_minimum_guard_band,
+)
 
 
 class TestGetCarrierBandwidth:

--- a/tests/unit/test_charm_collect_status.py
+++ b/tests/unit/test_charm_collect_status.py
@@ -10,11 +10,19 @@ from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 
 from tests.unit.fixtures import F1_PROVIDER_DATA, DUFixtures
 
+SAMPLE_CONFIG = {
+    "bandwidth": 20,
+    "frequency-band": 77,
+    "sub-carrier-spacing": 15,
+    "center-frequency": "3500",
+}
+
 
 class TestCharmCollectStatus(DUFixtures):
     def test_given_unit_is_not_leader_when_collect_status_then_status_is_blocked(self):
         state_in = testing.State(
             leader=False,
+            config=SAMPLE_CONFIG,
         )
 
         state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state_in)
@@ -35,7 +43,7 @@ class TestCharmCollectStatus(DUFixtures):
     ):
         state_in = testing.State(
             leader=True,
-            config={config_param: value},
+            config={**SAMPLE_CONFIG, config_param: value},
         )
 
         state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state_in)
@@ -48,6 +56,7 @@ class TestCharmCollectStatus(DUFixtures):
         self.mock_k8s_multus.multus_is_available.return_value = False
         state_in = testing.State(
             leader=True,
+            config=SAMPLE_CONFIG,
         )
 
         state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state_in)
@@ -61,6 +70,7 @@ class TestCharmCollectStatus(DUFixtures):
         self.mock_k8s_multus.is_ready.return_value = False
         state_in = testing.State(
             leader=True,
+            config=SAMPLE_CONFIG,
         )
 
         state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state_in)
@@ -73,6 +83,7 @@ class TestCharmCollectStatus(DUFixtures):
         self.mock_du_security_context.is_privileged.return_value = False
         state_in = testing.State(
             leader=True,
+            config=SAMPLE_CONFIG,
         )
 
         state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state_in)
@@ -86,6 +97,7 @@ class TestCharmCollectStatus(DUFixtures):
         self.mock_du_usb_volume.is_mounted.return_value = False
         state_in = testing.State(
             leader=True,
+            config=SAMPLE_CONFIG,
         )
 
         state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state_in)
@@ -99,6 +111,7 @@ class TestCharmCollectStatus(DUFixtures):
         self.mock_du_usb_volume.is_mounted.return_value = True
         state_in = testing.State(
             leader=True,
+            config=SAMPLE_CONFIG,
         )
 
         state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state_in)
@@ -122,6 +135,7 @@ class TestCharmCollectStatus(DUFixtures):
             leader=True,
             relations=[f1_relation],
             containers=[container],
+            config=SAMPLE_CONFIG,
         )
 
         state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state_in)
@@ -146,6 +160,7 @@ class TestCharmCollectStatus(DUFixtures):
             leader=True,
             relations=[f1_relation],
             containers=[container],
+            config=SAMPLE_CONFIG,
         )
 
         state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state_in)
@@ -170,6 +185,7 @@ class TestCharmCollectStatus(DUFixtures):
             leader=True,
             relations=[f1_relation],
             containers=[container],
+            config=SAMPLE_CONFIG,
         )
 
         state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state_in)
@@ -203,6 +219,7 @@ class TestCharmCollectStatus(DUFixtures):
                 leader=True,
                 relations=[f1_relation],
                 containers=[container],
+                config=SAMPLE_CONFIG,
             )
 
             state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state_in)
@@ -236,6 +253,7 @@ class TestCharmCollectStatus(DUFixtures):
                 leader=True,
                 relations=[f1_relation],
                 containers=[container],
+                config=SAMPLE_CONFIG,
             )
 
             state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state_in)

--- a/tests/unit/test_charm_collect_status.py
+++ b/tests/unit/test_charm_collect_status.py
@@ -11,10 +11,10 @@ from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from tests.unit.fixtures import F1_PROVIDER_DATA, DUFixtures
 
 SAMPLE_CONFIG = {
+    "center-frequency": "3600",
     "bandwidth": 20,
-    "frequency-band": 77,
+    "frequency-band": 78,
     "sub-carrier-spacing": 15,
-    "center-frequency": "3500",
 }
 
 
@@ -38,7 +38,7 @@ class TestCharmCollectStatus(DUFixtures):
             pytest.param("f1-port", int(), id="empty_f1_port"),
         ],
     )
-    def test_given_invalid_config_when_collect_status_then_status_is_blocked(
+    def test_given_invalid_f1_config_when_collect_status_then_status_is_blocked(
         self, config_param, value
     ):
         state_in = testing.State(
@@ -48,6 +48,92 @@ class TestCharmCollectStatus(DUFixtures):
 
         state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state_in)
 
+        assert state_out.unit_status == BlockedStatus(
+            f"The following configurations are not valid: ['{config_param}']"
+        )
+
+    @pytest.mark.parametrize(
+        "config_param,value",
+        [
+            pytest.param("center-frequency", "", id="empty_center_frequency"),
+            pytest.param("center-frequency", "invalid", id="string_center_frequency"),
+            pytest.param("center-frequency", "409", id="too_small_center_frequency"),
+            pytest.param("center-frequency", "7126", id="too_big_center_frequency"),
+        ],
+    )
+    def test_given_invalid_center_frequency_when_collect_status_then_status_is_blocked(
+        self, config_param, value
+    ):
+        state_in = testing.State(
+            leader=True,
+            config={**SAMPLE_CONFIG, config_param: value},
+        )
+        state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state_in)
+        assert state_out.unit_status == BlockedStatus(
+            f"The following configurations are not valid: ['{config_param}']"
+        )
+
+    @pytest.mark.parametrize(
+        "config_param,value",
+        [
+            pytest.param("bandwidth", int(), id="empty_bandwidth"),
+            pytest.param("bandwidth", 73, id="not_allowed_bandwidth"),
+            pytest.param("bandwidth", 0, id="zero_bandwidth"),
+            pytest.param("bandwidth", -1, id="negative_bandwidth"),
+        ],
+    )
+    def test_given_invalid_bandwidth_when_collect_status_then_status_is_blocked(
+        self, config_param, value
+    ):
+        state_in = testing.State(
+            leader=True,
+            config={**SAMPLE_CONFIG, config_param: value},
+        )
+        state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state_in)
+        assert state_out.unit_status == BlockedStatus(
+            f"The following configurations are not valid:"
+            f" ['{config_param}', 'center-frequency', 'sub-carrier-spacing']"
+        )
+
+    @pytest.mark.parametrize(
+        "config_param,value",
+        [
+            pytest.param("frequency-band", int(), id="empty_frequency_band"),
+            pytest.param("frequency-band", 0, id="zero_frequency_band"),
+            pytest.param("frequency-band", -1, id="negatibe_frequency_band"),
+            pytest.param("frequency-band", 120, id="too_high_frequency_band"),
+        ],
+    )
+    def test_given_invalid_frequency_band_when_collect_status_then_status_is_blocked(
+        self, config_param, value
+    ):
+        state_in = testing.State(
+            leader=True,
+            config={**SAMPLE_CONFIG, config_param: value},
+        )
+        state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state_in)
+        assert state_out.unit_status == BlockedStatus(
+            f"The following configurations are not valid: "
+            f"['center-frequency', '{config_param}', 'sub-carrier-spacing']"
+        )
+
+    @pytest.mark.parametrize(
+        "config_param,value",
+        [
+            pytest.param("sub-carrier-spacing", int(), id="empty_sub_carrier_spacing"),
+            pytest.param("sub-carrier-spacing", 7, id="too_low_sub_carrier_spacing"),
+            pytest.param("sub-carrier-spacing", -1, id="negative_sub_carrier_spacing"),
+            pytest.param("sub-carrier-spacing", 240, id="too_large_sub_carrier_spacing"),
+        ],
+    )
+    def test_given_invalid_sub_carrier_spacing_when_collect_status_then_status_is_blocked(
+        self, config_param, value
+    ):
+        state_in = testing.State(
+            leader=True,
+            config={**SAMPLE_CONFIG, config_param: value},
+        )
+        state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state_in)
         assert state_out.unit_status == BlockedStatus(
             f"The following configurations are not valid: ['{config_param}']"
         )
@@ -226,7 +312,17 @@ class TestCharmCollectStatus(DUFixtures):
 
             assert state_out.unit_status == WaitingStatus("Waiting for F1 information")
 
-    def test_given_all_prerequisites_met_when_collect_status_then_status_is_active(self):
+    @pytest.mark.parametrize(
+        "frequency_band,center_frequency,sub_carrier_spacing,bandwidth",
+        [
+            pytest.param(34, "2020.21", 15, 5, id="minimum_valid_frequency_band"),
+            pytest.param(77, "3500.002", 15, 30, id="midrange_valid_frequency_band"),
+            pytest.param(102, "6000", 60, 40, id="maximum_valid_frequency_band"),
+        ],
+    )
+    def test_given_all_prerequisites_met_when_collect_status_then_status_is_active(
+        self, frequency_band, center_frequency, sub_carrier_spacing, bandwidth
+    ):
         with tempfile.TemporaryDirectory() as temp_dir:
             self.mock_k8s_multus.multus_is_available.return_value = True
             self.mock_k8s_multus.is_ready.return_value = True
@@ -253,7 +349,12 @@ class TestCharmCollectStatus(DUFixtures):
                 leader=True,
                 relations=[f1_relation],
                 containers=[container],
-                config=SAMPLE_CONFIG,
+                config={
+                    "frequency-band": frequency_band,
+                    "center-frequency": center_frequency,
+                    "sub-carrier-spacing": sub_carrier_spacing,
+                    "bandwidth": bandwidth,
+                },
             )
 
             state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state_in)

--- a/tests/unit/test_charm_config.py
+++ b/tests/unit/test_charm_config.py
@@ -1,0 +1,239 @@
+import pytest
+from pydantic import ValidationError
+
+from src.charm_config import DUConfig
+
+
+class TestFrequencyBandValidation:
+    @pytest.mark.parametrize(
+        "frequency_band, center_frequency",
+        [
+            (48, "3590.33"),
+            (77, "3500"),
+            (38, "2590.5"),
+            (102, "5940"),
+        ],
+    )
+    def test_frequency_band_validation_when_valid_values_given_then_return_expected_results(
+        self, frequency_band, center_frequency
+    ):
+        config = {
+            "f1-port": 8080,
+            "frequency-band": frequency_band,
+            "bandwidth": 20,
+            "sub-carrier-spacing": 15,
+            "center-frequency": center_frequency,
+        }
+        assert DUConfig(**config).frequency_band == frequency_band
+
+    @pytest.mark.parametrize(
+        "frequency_band",
+        [
+            103,
+            33,
+            500,
+        ],
+    )
+    def test_frequency_band_validation_when_invalid_values_given_then_raise_error(
+        self, frequency_band
+    ):
+        config = {
+            "f1-port": 8080,
+            "frequency-band": frequency_band,
+            "bandwidth": 40,
+            "sub-carrier-spacing": 30,
+            "center-frequency": "3500.22",
+        }
+        with pytest.raises(ValidationError):
+            DUConfig(**config)
+
+
+class TestBandwidthValidation:
+    @pytest.mark.parametrize(
+        "bandwidth, frequency_band, sub_carrier_spacing, center_frequency",
+        [
+            (20, 38, 30, "2590"),
+            (15, 77, 15, "3700"),
+            (100, 77, 60, "3700"),
+            (40, 79, 30, "4520"),
+        ],
+    )
+    def test_bandwidth_validation_when_valid_values_given_then_return_expected_values(
+        self, bandwidth, frequency_band, sub_carrier_spacing, center_frequency
+    ):
+        config = {
+            "f1-port": 8080,
+            "bandwidth": bandwidth,
+            "frequency-band": frequency_band,
+            "sub-carrier-spacing": sub_carrier_spacing,
+            "center-frequency": center_frequency,
+        }
+        assert DUConfig(**config).bandwidth == bandwidth
+
+    @pytest.mark.parametrize(
+        "bandwidth, frequency_band, sub_carrier_spacing",
+        [
+            (200, 77, 30),
+            (3, 38, 15),
+            (50, 103, 15),
+            (60, 40, 25),
+        ],
+    )
+    def test_bandwidth_validation_when_invalid_values_given_then_raise_error(
+        self, bandwidth, frequency_band, sub_carrier_spacing
+    ):
+        config = {
+            "f1-port": 8080,
+            "bandwidth": bandwidth,
+            "frequency-band": frequency_band,
+            "sub-carrier-spacing": sub_carrier_spacing,
+            "center-frequency": "3500",
+        }
+        with pytest.raises(ValidationError or ValueError):
+            DUConfig(**config)
+
+
+class TestCenterFrequencyValidation:
+    @pytest.mark.parametrize(
+        "center_frequency, frequency_band, bandwidth, subcarrier_spacing",
+        [
+            ("3750", 77, 40, 30),
+            ("6025.11", 96, 40, 30),
+            ("1429.5", 51, 5, 15),
+            ("3330", 78, 50, 15),
+            ("6100", 96, 60, 30),
+        ],
+    )
+    def test_center_frequency_validation_when_valid_inputs_given_then_return_expected_result(
+        self, center_frequency, frequency_band, bandwidth, subcarrier_spacing
+    ):
+        config = {
+            "f1-port": 8080,
+            "center-frequency": center_frequency,
+            "frequency-band": frequency_band,
+            "bandwidth": bandwidth,
+            "sub-carrier-spacing": subcarrier_spacing,
+        }
+        assert DUConfig(**config).center_frequency == center_frequency
+
+    @pytest.mark.parametrize(
+        "center_frequency, frequency_band, bandwidth",
+        [
+            ("4201", 77, 40),
+            ("1431", 51, 5),
+            ("8000", 96, 60),
+        ],
+    )
+    def test_center_frequency_validation_when_invalid_input_given_then_raise_error(
+        self, center_frequency, frequency_band, bandwidth
+    ):
+        config = {
+            "f1-port": 8080,
+            "center-frequency": center_frequency,
+            "frequency-band": frequency_band,
+            "bandwidth": bandwidth,
+            "sub-carrier-spacing": 30,
+        }
+
+        with pytest.raises(
+            ValidationError,
+            match=f"Center_frequency {center_frequency} must be within the usable range",
+        ):
+            DUConfig(**config)
+
+
+class TestSubCarrierSpacingValidation:
+    @pytest.mark.parametrize(
+        "sub_carrier_spacing, frequency_band, bandwidth, center_frequency",
+        [
+            (30, 38, 40, "2599"),
+            (15, 34, 10, "2016"),
+            (60, 77, 100, "3360"),
+            (30, 90, 80, "2540"),
+        ],
+    )
+    def test_sub_carrier_spacing_validation_when_valid_input_given_then_return_expected_result(
+        self, sub_carrier_spacing, frequency_band, bandwidth, center_frequency
+    ):
+        config = {
+            "f1-port": 8080,
+            "sub-carrier-spacing": sub_carrier_spacing,
+            "frequency-band": frequency_band,
+            "bandwidth": bandwidth,
+            "center-frequency": center_frequency,
+        }
+        assert DUConfig(**config).sub_carrier_spacing == sub_carrier_spacing
+
+    @pytest.mark.parametrize(
+        "sub_carrier_spacing, frequency_band, bandwidth",
+        [
+            (15, 38, 100),
+            (25, 77, 50),
+            (60, 51, 5),
+            (15, 40, 12),
+        ],
+    )
+    def test_sub_carrier_spacing_validation_when_invalid_input_given_then_raise_error(
+        self, sub_carrier_spacing, frequency_band, bandwidth
+    ):
+        config = {
+            "f1-port": 8080,
+            "sub-carrier-spacing": sub_carrier_spacing,
+            "frequency-band": frequency_band,
+            "bandwidth": bandwidth,
+            "center-frequency": "3500",
+        }
+        with pytest.raises(ValidationError):
+            DUConfig(**config)
+
+
+class TestFullDUConfigValidation:
+    @pytest.mark.parametrize(
+        "frequency_band, bandwidth, sub_carrier_spacing, center_frequency",
+        [
+            (38, 40, 30, "2592"),
+            (77, 100, 60, "3700"),
+            (78, 20, 30, "3400"),
+        ],
+    )
+    def test_full_du_config_validation_for_all_attributes_when_valid_inputs_given_then_return_expected_results(  # noqa: E501
+        self,
+        frequency_band,
+        bandwidth,
+        sub_carrier_spacing,
+        center_frequency,
+    ):
+        config = {
+            "f1-port": 8080,
+            "frequency-band": frequency_band,
+            "bandwidth": bandwidth,
+            "sub-carrier-spacing": sub_carrier_spacing,
+            "center-frequency": center_frequency,
+        }
+        assert DUConfig(**config).frequency_band == frequency_band
+        assert DUConfig(**config).bandwidth == bandwidth
+        assert DUConfig(**config).sub_carrier_spacing == sub_carrier_spacing
+        assert DUConfig(**config).center_frequency == center_frequency
+
+    @pytest.mark.parametrize(
+        "frequency_band, bandwidth, sub_carrier_spacing, center_frequency",
+        [
+            (77, 150, 60, "3700"),
+            (77, 40, 15, "5000"),
+            (33, 40, 30, "3500"),
+            (90, 25, 20, "2500"),
+            (38, 40, 30, "20000"),
+        ],
+    )
+    def test_full_du_config_validation_for_all_attributes_when_invalid_inputs_given_then_raise_error(  # noqa: E501
+        self, frequency_band, bandwidth, sub_carrier_spacing, center_frequency
+    ):
+        config = {
+            "f1-port": 8080,
+            "frequency-band": frequency_band,
+            "bandwidth": bandwidth,
+            "sub-carrier-spacing": sub_carrier_spacing,
+            "center-frequency": center_frequency,
+        }
+        with pytest.raises(ValueError):
+            DUConfig(**config)

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -23,6 +23,13 @@ F1_PROVIDER_DATA_MULTIPLE_PLMNS = ProviderAppData(
     ],
 )
 
+SAMPLE_CONFIG = {
+    "bandwidth": 20,
+    "frequency-band": 77,
+    "sub-carrier-spacing": 15,
+    "center-frequency": "3500",
+}
+
 
 class TestCharmConfigure(DUFixtures):
     def test_given_statefulset_is_not_patched_when_configure_then_usb_is_mounted_and_privileged_context_is_set(  # noqa: E501
@@ -37,6 +44,7 @@ class TestCharmConfigure(DUFixtures):
         state_in = testing.State(
             leader=True,
             containers=[container],
+            config=SAMPLE_CONFIG,
         )
 
         self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
@@ -56,7 +64,7 @@ class TestCharmConfigure(DUFixtures):
         state_in = testing.State(
             leader=True,
             containers=[container],
-            config={"simulation-mode": True},
+            config={**SAMPLE_CONFIG, "simulation-mode": True},
         )
 
         self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
@@ -76,6 +84,7 @@ class TestCharmConfigure(DUFixtures):
         state_in = testing.State(
             leader=True,
             containers=[container],
+            config=SAMPLE_CONFIG,
         )
 
         self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
@@ -124,6 +133,7 @@ class TestCharmConfigure(DUFixtures):
                 relations=[f1_relation],
                 containers=[container],
                 model=testing.Model(name="whatever"),
+                config=SAMPLE_CONFIG,
             )
 
             self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
@@ -164,7 +174,7 @@ class TestCharmConfigure(DUFixtures):
                 relations=[f1_relation],
                 containers=[container],
                 model=testing.Model(name="whatever"),
-                config={"simulation-mode": True},
+                config={**SAMPLE_CONFIG, "simulation-mode": True},
             )
 
             self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
@@ -207,6 +217,7 @@ class TestCharmConfigure(DUFixtures):
                 relations=[f1_relation],
                 containers=[container],
                 model=testing.Model(name="whatever"),
+                config=SAMPLE_CONFIG,
             )
             with open("tests/unit/resources/expected_config.conf") as expected_config_file:
                 expected_config = expected_config_file.read().strip()
@@ -246,6 +257,7 @@ class TestCharmConfigure(DUFixtures):
                 relations=[f1_relation],
                 containers=[container],
                 model=testing.Model(name="whatever"),
+                config=SAMPLE_CONFIG,
             )
 
             state_out = self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
@@ -309,6 +321,7 @@ class TestCharmConfigure(DUFixtures):
                 containers=[container],
                 model=testing.Model(name="whatever"),
                 config={
+                    **SAMPLE_CONFIG,
                     "simulation-mode": simulation_mode,
                     "use-three-quarter-sampling": three_quarter_sampling,
                 },
@@ -360,7 +373,7 @@ class TestCharmConfigure(DUFixtures):
                 relations=[f1_relation],
                 containers=[container],
                 model=testing.Model(name="whatever"),
-                config={"simulation-mode": True},
+                config={**SAMPLE_CONFIG, "simulation-mode": True},
             )
 
             self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
@@ -399,7 +412,7 @@ class TestCharmConfigure(DUFixtures):
                 relations=[f1_relation, rfsim_relation],
                 containers=[container],
                 model=testing.Model(name="whatever"),
-                config={"simulation-mode": True},
+                config={**SAMPLE_CONFIG, "simulation-mode": True},
             )
 
             self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
@@ -438,7 +451,7 @@ class TestCharmConfigure(DUFixtures):
                 relations=[f1_relation, rfsim_relation],
                 containers=[container],
                 model=testing.Model(name="whatever"),
-                config={"simulation-mode": True},
+                config={**SAMPLE_CONFIG, "simulation-mode": True},
             )
 
             self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
@@ -477,7 +490,7 @@ class TestCharmConfigure(DUFixtures):
                 relations=[f1_relation, rfsim_relation],
                 containers=[container],
                 model=testing.Model(name="whatever"),
-                config={"simulation-mode": True},
+                config={**SAMPLE_CONFIG, "simulation-mode": True},
             )
 
             self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
@@ -511,7 +524,7 @@ class TestCharmConfigure(DUFixtures):
                 relations=[rfsim_relation],
                 containers=[container],
                 model=testing.Model(name="whatever"),
-                config={"simulation-mode": True},
+                config={**SAMPLE_CONFIG, "simulation-mode": True},
             )
 
             self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
@@ -550,7 +563,7 @@ class TestCharmConfigure(DUFixtures):
                 relations=[f1_relation, rfsim_relation],
                 containers=[container],
                 model=testing.Model(name="whatever"),
-                config={"simulation-mode": True},
+                config={**SAMPLE_CONFIG, "simulation-mode": True},
             )
 
             self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
@@ -585,6 +598,7 @@ class TestCharmConfigure(DUFixtures):
                 relations=[f1_relation],
                 containers=[container],
                 model=testing.Model(name="whatever"),
+                config=SAMPLE_CONFIG,
             )
 
             self.ctx.run(self.ctx.on.pebble_ready(container), state_in)

--- a/tests/unit/test_charm_remove.py
+++ b/tests/unit/test_charm_remove.py
@@ -7,6 +7,13 @@ from ops import testing
 
 from tests.unit.fixtures import DUFixtures
 
+SAMPLE_CONFIG = {
+    "bandwidth": 20,
+    "frequency-band": 77,
+    "sub-carrier-spacing": 15,
+    "center-frequency": "3500",
+}
+
 
 class TestCharmRemove(DUFixtures):
     def test_given_unit_is_leader_when_remove_then_k8s_multus_is_removed(self):
@@ -14,7 +21,7 @@ class TestCharmRemove(DUFixtures):
             name="du",
             can_connect=False,
         )
-        state_in = testing.State(leader=True, containers=[container])
+        state_in = testing.State(leader=True, containers=[container], config=SAMPLE_CONFIG)
 
         self.ctx.run(self.ctx.on.remove(), state_in)
 

--- a/tests/unit/test_initial_bwp.py
+++ b/tests/unit/test_initial_bwp.py
@@ -3,7 +3,7 @@
 import pytest
 
 from src.du_parameters.initial_bwp import (
-    calculate_initial_bwp,
+    get_initial_bwp,
 )
 
 
@@ -15,7 +15,7 @@ class TestCalculateInitialBWP:
     def test_calculate_initial_bwp_when_valid_inputs_given_then_return_expected_results(
         self, carrier_bandwidth, expected_bwp
     ):
-        assert calculate_initial_bwp(carrier_bandwidth) == expected_bwp
+        assert get_initial_bwp(carrier_bandwidth) == expected_bwp
 
     @pytest.mark.parametrize(
         "carrier_bandwidth, error_type, error_message",
@@ -28,12 +28,12 @@ class TestCalculateInitialBWP:
         self, carrier_bandwidth, error_type, error_message
     ):
         with pytest.raises(error_type) as e:
-            calculate_initial_bwp(carrier_bandwidth)
+            get_initial_bwp(carrier_bandwidth)
         assert error_message in str(e.value)
 
     def test_calculate_initial_bwp_when_unsupported_carrier_bandwidth_value_given_then_raise_value_error(  # noqa: E501
         self,
     ):
         with pytest.raises(ValueError) as e:
-            calculate_initial_bwp(0)
+            get_initial_bwp(0)
         assert "Carrier bandwidth must be greater than 0" in str(e.value)

--- a/tests/unit/test_initial_bwp.py
+++ b/tests/unit/test_initial_bwp.py
@@ -2,71 +2,20 @@
 # See LICENSE file for licensing details.
 import pytest
 
-from src.du_parameters.frequency import GSCN, Frequency
 from src.du_parameters.initial_bwp import (
-    CalculateBWPLocationBandwidthError,
     calculate_initial_bwp,
-    get_total_prbs_from_scs,
 )
-
-
-class TestGetTotalPRBs:
-    @pytest.mark.parametrize(
-        "scs,expected_prbs",
-        [
-            (Frequency.from_khz(15), 275),
-            (Frequency.from_khz(30), 275),
-            (Frequency.from_khz(60), 135),
-        ],
-    )
-    def test_get_total_prbs_from_scs_when_valid_inputs_given_then_return_expected_results(
-        self, scs, expected_prbs
-    ):
-        assert get_total_prbs_from_scs(scs) == expected_prbs
-
-    @pytest.mark.parametrize(
-        "scs",
-        [
-            "invalid",
-            None,
-            3.43,
-            23232,
-        ],
-    )
-    def test_get_total_prbs_from_scs_when_invalid_type_inputs_given_then_raise_type_error(
-        self, scs
-    ):
-        with pytest.raises(
-            ValueError,
-            match=f"Subcarrier spacing value {scs} is not supported."
-            f"Supported values: 15000, 30000, 60000",
-        ):
-            get_total_prbs_from_scs(scs)
-
-    def test_get_total_prbs_from_scs_when_unsupported_value_given_then_raise_value_error(self):
-        invalid_scs = Frequency.from_khz(10)
-        with pytest.raises(
-            ValueError,
-            match="Subcarrier spacing value 10000 is not supported."
-            "Supported values: 15000, 30000, 60000",
-        ):
-            get_total_prbs_from_scs(invalid_scs)
 
 
 class TestCalculateInitialBWP:
     @pytest.mark.parametrize(
-        "carrier_bandwidth,scs,expected_bwp",
-        [
-            (1, Frequency.from_khz(15), 0),
-            (2, Frequency.from_khz(15), 275),
-            (3, Frequency.from_khz(30), 550),
-            (1, Frequency.from_khz(60), 0),
-        ],
+        "carrier_bandwidth,expected_bwp",
+        [(1, 0), (2, 275), (3, 550), (1, 0), (106, 28875), (50, 13475)],
     )
     def test_calculate_initial_bwp_when_valid_inputs_given_then_return_expected_results(
-        self, carrier_bandwidth, scs, expected_bwp
+        self, carrier_bandwidth, expected_bwp
     ):
-        assert calculate_initial_bwp(carrier_bandwidth, scs) == expected_bwp
+        assert calculate_initial_bwp(carrier_bandwidth) == expected_bwp
 
     @pytest.mark.parametrize(
         "carrier_bandwidth, error_type, error_message",
@@ -79,38 +28,12 @@ class TestCalculateInitialBWP:
         self, carrier_bandwidth, error_type, error_message
     ):
         with pytest.raises(error_type) as e:
-            calculate_initial_bwp(carrier_bandwidth, Frequency.from_khz(15))
+            calculate_initial_bwp(carrier_bandwidth)
         assert error_message in str(e.value)
 
-    @pytest.mark.parametrize(
-        "scs",
-        [
-            "invalid",
-            None,
-            4.23,
-            GSCN(23),
-        ],
-    )
-    def test_calculate_initial_bwp_when_invalid_type_scs_given_then_raise_type_error(self, scs):
-        with pytest.raises(
-            CalculateBWPLocationBandwidthError, match="Error calculating total PRBs"
-        ):
-            calculate_initial_bwp(1, scs)
-
-    def test_calculate_initial_bwp__when_unsupported_carrier_bandwidth_value_given_then_raise_value_error(  # noqa: E501
+    def test_calculate_initial_bwp_when_unsupported_carrier_bandwidth_value_given_then_raise_value_error(  # noqa: E501
         self,
     ):
         with pytest.raises(ValueError) as e:
-            calculate_initial_bwp(0, Frequency.from_khz(15))
+            calculate_initial_bwp(0)
         assert "Carrier bandwidth must be greater than 0" in str(e.value)
-
-    def test_calculate_initial_bwp_when_get_total_prb_calculation_fails_then_raise_calculate_bwp_location_bandwidth_error(  # noqa: E501
-        self,
-    ):
-        with pytest.raises(
-            CalculateBWPLocationBandwidthError,
-            match="Error calculating total PRBs using 2 and 10000: "
-            "Subcarrier spacing value 10000 is not supported."
-            "Supported values: 15000, 30000, 60000",
-        ):
-            calculate_initial_bwp(2, Frequency.from_khz(10))

--- a/tests/unit/test_initial_bwp.py
+++ b/tests/unit/test_initial_bwp.py
@@ -15,9 +15,8 @@ class TestGetTotalPRBs:
         "scs,expected_prbs",
         [
             (Frequency.from_khz(15), 275),
-            (Frequency.from_khz(30), 137),
-            (Frequency.from_khz(60), 69),
-            (Frequency.from_khz(120), 33),
+            (Frequency.from_khz(30), 275),
+            (Frequency.from_khz(60), 135),
         ],
     )
     def test_get_total_prbs_from_scs_when_valid_inputs_given_then_return_expected_results(
@@ -40,7 +39,7 @@ class TestGetTotalPRBs:
         with pytest.raises(
             ValueError,
             match=f"Subcarrier spacing value {scs} is not supported."
-            f"Supported values: 15000, 30000, 60000, 120000",
+            f"Supported values: 15000, 30000, 60000",
         ):
             get_total_prbs_from_scs(scs)
 
@@ -49,7 +48,7 @@ class TestGetTotalPRBs:
         with pytest.raises(
             ValueError,
             match="Subcarrier spacing value 10000 is not supported."
-            "Supported values: 15000, 30000, 60000, 120000",
+            "Supported values: 15000, 30000, 60000",
         ):
             get_total_prbs_from_scs(invalid_scs)
 
@@ -60,9 +59,8 @@ class TestCalculateInitialBWP:
         [
             (1, Frequency.from_khz(15), 0),
             (2, Frequency.from_khz(15), 275),
-            (3, Frequency.from_khz(30), 274),
+            (3, Frequency.from_khz(30), 550),
             (1, Frequency.from_khz(60), 0),
-            (4, Frequency.from_khz(120), 99),
         ],
     )
     def test_calculate_initial_bwp_when_valid_inputs_given_then_return_expected_results(
@@ -113,6 +111,6 @@ class TestCalculateInitialBWP:
             CalculateBWPLocationBandwidthError,
             match="Error calculating total PRBs using 2 and 10000: "
             "Subcarrier spacing value 10000 is not supported."
-            "Supported values: 15000, 30000, 60000, 120000",
+            "Supported values: 15000, 30000, 60000",
         ):
             calculate_initial_bwp(2, Frequency.from_khz(10))


### PR DESCRIPTION
# Description

This PR exposes the following parameters to be used for RAN configuration according to https://docs.google.com/document/d/1f_SPGr5COHTlTbrmJjzYkDrBjvhEeR9XH8JPc8DZa_Q/edit?tab=t.0. This PR does not change the charm code to use new exposed parameters as this is subject to another task and it will be implemented with another PR.

- bandwidth (MHz): the width of radio frequencies, centered on the center frequency 
- center frequency (MHz): the  frequency which is permitted by statutory regulations
- frequency band (prefix of N in FR1 TDD): a frequency range which is defined in FR1 5G spectrum
- subcarrier spacing (KHz): the distance between two adjacent subcarriers

Validations:
- Each parameter is validated according to acceptable values or ranges
- Frequency band uplink/downlink frequency is validated to check if it covers the central frequency 
- Subcarrier spacing is validated according to frequency band allowed channel bandwidths

Auto generation of DU config file:

According to given configuration parameters, all necessary DU configuration parameters will be calculated and DU configuration file will be generated.

Note: We confirmed with Anna that generated configuration file worked well and UE registered.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library