### PR TITLE
feat: Implements possibility of passing UE simulator startup params over the fiveg_rfsim relation

### DIFF
--- a/lib/charms/oai_ran_du_k8s/v0/fiveg_rfsim.py
+++ b/lib/charms/oai_ran_du_k8s/v0/fiveg_rfsim.py
@@ -440,7 +440,8 @@ class RFSIMRequires(Object):
             return remote_app_relation_data.start_subcarrier
         return None
 
-    def get_provider_rfsim_information(self, relation: Optional[Relation] = None
+    def get_provider_rfsim_information(
+        self, relation: Optional[Relation] = None
     ) -> Optional[ProviderAppData]:
         """Get relation data for the remote application.
 

--- a/lib/charms/oai_ran_du_k8s/v0/fiveg_rfsim.py
+++ b/lib/charms/oai_ran_du_k8s/v0/fiveg_rfsim.py
@@ -6,7 +6,7 @@
 This library contains the Requires and Provides classes for handling the `fiveg_rfsim` interface.
 
 The purpose of this library is to relate two charms to pass the network configuration data required to start the RF simulation.
-In particular the RF SIM address, Network Slice Type (SST), Slice Differentiator (SD), RF band, downlink frequency, carrier bandwidth, numerology and the numer of the first usable subcarrier will be passed through the interface.
+In particular the RF SIM address, Network Slice Type (SST), Slice Differentiator (SD), RF band, downlink frequency, carrier bandwidth, numerology and the number of the first usable subcarrier will be passed through the interface.
 In the Telco world this will typically be charms implementing the DU (Distributed Unit) and the UE (User equipment).
 
 ## Getting Started
@@ -62,7 +62,7 @@ class DummyFivegRFSIMProviderCharm(CharmBase):
                 dl_freq=self.DL_FREQ,
                 carrier_bandwidth=self.CARRIER_BANDWIDTH,
                 numerology=self.NUMEROLOGY,
-                NUMEROLOGY=self.START_SUBCARRIER
+                start_subcarrier=self.START_SUBCARRIER
             )
 
 
@@ -387,10 +387,10 @@ class RFSIMRequires(Object):
 
     @property
     def band(self) -> Optional[int]:
-        """Return the RF Band numer.
+        """Return the RF Band number.
 
         Returns:
-           Optional[int] : band (RF Band numer)
+           Optional[int] : band (RF Band number)
         """
         if remote_app_relation_data := self.get_provider_rfsim_information():
             return remote_app_relation_data.band

--- a/lib/charms/oai_ran_du_k8s/v0/fiveg_rfsim.py
+++ b/lib/charms/oai_ran_du_k8s/v0/fiveg_rfsim.py
@@ -5,9 +5,9 @@
 
 This library contains the Requires and Provides classes for handling the `fiveg_rfsim` interface.
 
-The purpose of this library is to relate two charms to pass the RF SIM address and network information (SST and SD).
-In the Telco world this will typically be charms implementing
-the DU (Distributed Unit) and the UE (User equipment).
+The purpose of this library is to relate two charms to pass the network configuration data required to start the RF simulation.
+In particular the RF SIM address, Network Slice Type (SST), Slice Differentiator (SD), RF band, downlink frequency, carrier bandwidth, numerology and the numer of the first usable subcarrier will be passed through the interface.
+In the Telco world this will typically be charms implementing the DU (Distributed Unit) and the UE (User equipment).
 
 ## Getting Started
 From a charm directory, fetch the library using `charmcraft`:
@@ -21,7 +21,7 @@ Add the following libraries to the charm's `requirements.txt` file:
 - pytest-interface-tester
 
 ### Provider charm
-The provider charm is the one providing the information about RF SIM address, Network Slice Type (SST) and Network Differentiator (SD).
+The provider charm is the one providing the information about RF SIM address, SST, SD, RF band, downlink frequency, carrier bandwidth, numerology and the numer of the first usable subcarrier.
 Typically, this will be the DU charm.
 
 Example:
@@ -38,6 +38,11 @@ class DummyFivegRFSIMProviderCharm(CharmBase):
     RFSIM_ADDRESS = "192.168.70.130"
     SST = 1
     SD = 1
+    BAND = 77
+    DL_FREQ = 4059090000  # In Hz
+    CARRIER_BANDWIDTH = 106  # In PRBs
+    NUMEROLOGY = 1
+    START_SUBCARRIER = 541
 
     def __init__(self, *args):
         super().__init__(*args)
@@ -49,9 +54,15 @@ class DummyFivegRFSIMProviderCharm(CharmBase):
     def _on_fiveg_rfsim_relation_changed(self, event: RelationChangedEvent):
         if self.unit.is_leader():
             self.rfsim_provider.set_rfsim_information(
-                rfsim_address=self.RFSIM_ADDRESS
+                version=0,
+                rfsim_address=self.RFSIM_ADDRESS,
                 sst=self.SST,
                 sd=self.SD,
+                band=self.BAND,
+                dl_freq=self.DL_FREQ,
+                carrier_bandwidth=self.CARRIER_BANDWIDTH,
+                numerology=self.NUMEROLOGY,
+                NUMEROLOGY=self.START_SUBCARRIER
             )
 
 
@@ -87,7 +98,12 @@ class DummyFivegRFSIMRequires(CharmBase):
         provider_rfsim_address = event.rfsim_address
         provider_sst = event.sst
         provider_st = event.sd
-        <do something with the rfsim address, SST and SD here>
+        provider_band = event.band
+        provider_dl_freq = event.dl_freq
+        provider_carrier_bandwidth = event.carrier_bandwidth
+        provider_numerology = event.numerology
+        provider_start_subcarrier = event.start_subcarrier
+        <do something with the received data>
 
 
 if __name__ == "__main__":
@@ -115,7 +131,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 
 logger = logging.getLogger(__name__)
@@ -128,19 +144,32 @@ Examples:
     ProviderSchema:
         unit: <empty>
         app: {
+            "version": 0,
             "rfsim_address": "192.168.70.130",
             "sst": 1,
             "sd": 1,
+            "band": 77,
+            "dl_freq": 4059090000,
+            "carrier_bandwidth": 106,
+            "numerology": 1,
+            "start_subcarrier": 541,
         }
     RequirerSchema:
         unit: <empty>
-        app:  <empty>
+        app: {
+            "version": 0,
+        }
 """
 
 
 class ProviderAppData(BaseModel):
     """Provider app data for fiveg_rfsim."""
 
+    version: int = Field(
+        description="Interface version",
+        examples=[0, 1, 2, 3],
+        ge=0,
+    )
     rfsim_address: IPvAnyAddress = Field(
         description="RF simulator service address which is equal to DU pod ip",
         examples=["192.168.70.130"],
@@ -158,12 +187,60 @@ class ProviderAppData(BaseModel):
         ge=0,
         le=16777215,
     )
+    band: int = Field(
+        description="Frequency band",
+        default=None,
+        examples=[34, 77, 102],
+        gt=0,
+    )
+    dl_freq: int = Field(
+        description="Downlink frequency in Hz",
+        default=None,
+        examples=[4059090000],
+        ge=410000000,
+    )
+    carrier_bandwidth: int = Field(
+        description="Carrier bandwidth (number of downlink PRBs)",
+        default=None,
+        examples=[106],
+        ge=11,
+        le=273,
+    )
+    numerology: int = Field(
+        description="Numerology",
+        default=None,
+        examples=[0, 1, 2, 3],
+        ge=0,
+        le=6,
+    )
+    start_subcarrier: int = Field(
+        description="First usable subcarrier",
+        default=None,
+        examples=[530, 541],
+        ge=0,
+    )
 
 
 class ProviderSchema(DataBagSchema):
     """Provider schema for the fiveg_rfsim interface."""
 
     app_data: ProviderAppData
+
+
+class RequirerAppData(BaseModel):
+    """Requirer app data for fiveg_rfsim."""
+
+    version: int = Field(
+        description="Interface version",
+        examples=[0, 1, 2, 3],
+        ge=0,
+    )
+
+
+class RequirerSchema(DataBagSchema):
+    """Requirer schema for the fiveg_rfsim interface."""
+
+    app_data: RequirerAppData
 
 
 def provider_data_is_valid(data: Dict[str, Any]) -> bool:
@@ -200,13 +277,28 @@ class RFSIMProvides(Object):
         self.relation_name = relation_name
         self.charm = charm
 
-    def set_rfsim_information(self, rfsim_address: str, sst: int, sd: Optional[int]) -> None:
+    def set_rfsim_information(
+        self,
+        rfsim_address: str,
+        sst: int,
+        sd: Optional[int],
+        band: int,
+        dl_freq: int,
+        carrier_bandwidth: int,
+        numerology: int,
+        start_subcarrier: int,
+    ) -> None:
         """Push the information about the RFSIM interface in the application relation data.
 
         Args:
             rfsim_address (str): rfsim service address which is equal to DU pod ip.
             sst (int): Slice/Service Type
             sd (Optional[int]): Slice Differentiator
+            band (int): Valid 5G band
+            dl_freq (int): Downlink frequency in Hz
+            carrier_bandwidth (int): Carrier bandwidth (number of downlink PRBs)
+            numerology (int): Numerology
+            start_subcarrier (int): First usable subcarrier
         """
         if not self.charm.unit.is_leader():
             raise FivegRFSIMError("Unit must be leader to set application relation data.")
@@ -215,20 +307,36 @@ class RFSIMProvides(Object):
             raise FivegRFSIMError(f"Relation {self.relation_name} not created yet.")
         if not provider_data_is_valid(
             {
+                "version": str(LIBAPI),
                 "rfsim_address": rfsim_address,
                 "sst": sst,
                 "sd": sd,
+                "band": band,
+                "dl_freq": dl_freq,
+                "carrier_bandwidth": carrier_bandwidth,
+                "numerology": numerology,
+                "start_subcarrier": start_subcarrier,
             }
         ):
             raise FivegRFSIMError("Invalid relation data")
         for relation in relations:
             data = {
+                "version": str(LIBAPI),
                 "rfsim_address": rfsim_address,
                 "sst": str(sst),
+                "band": str(band),
+                "dl_freq": str(dl_freq),
+                "carrier_bandwidth": str(carrier_bandwidth),
+                "numerology": str(numerology),
+                "start_subcarrier": str(start_subcarrier),
             }
             if sd is not None:
                 data["sd"] = str(sd)
             relation.data[self.charm.app].update(data)
+
+    @property
+    def interface_version(self):
+        return LIBAPI
 
 
 class RFSIMRequires(Object):
@@ -239,6 +347,10 @@ class RFSIMRequires(Object):
         super().__init__(charm, relation_name)
         self.charm = charm
         self.relation_name = relation_name
+
+    @property
+    def interface_version(self):
+        return LIBAPI
 
     @property
     def rfsim_address(self) -> Optional[IPvAnyAddress]:
@@ -273,6 +385,61 @@ class RFSIMRequires(Object):
             return remote_app_relation_data.sd
         return None
 
+    @property
+    def band(self) -> Optional[int]:
+        """Return the RF Band numer.
+
+        Returns:
+           Optional[int] : band (RF Band numer)
+        """
+        if remote_app_relation_data := self.get_provider_rfsim_information():
+            return remote_app_relation_data.band
+        return None
+
+    @property
+    def dl_freq(self) -> Optional[int]:
+        """Return the Downlink frequency.
+
+        Returns:
+           Optional[int] : dl_freq (Downlink frequency)
+        """
+        if remote_app_relation_data := self.get_provider_rfsim_information():
+            return remote_app_relation_data.dl_freq
+        return None
+
+    @property
+    def carrier_bandwidth(self) -> Optional[int]:
+        """Return the carrier bandwidth (number of downlink PRBs).
+
+        Returns:
+           Optional[int] : carrier_bandwidth (carrier bandwidth)
+        """
+        if remote_app_relation_data := self.get_provider_rfsim_information():
+            return remote_app_relation_data.carrier_bandwidth
+        return None
+
+    @property
+    def numerology(self) -> Optional[int]:
+        """Return numerology.
+
+        Returns:
+           Optional[int] : numerology
+        """
+        if remote_app_relation_data := self.get_provider_rfsim_information():
+            return remote_app_relation_data.numerology
+        return None
+
+    @property
+    def start_subcarrier(self) -> Optional[int]:
+        """Return number of the first usable subcarrier.
+
+        Returns:
+           Optional[int] : start_subcarrier
+        """
+        if remote_app_relation_data := self.get_provider_rfsim_information():
+            return remote_app_relation_data.start_subcarrier
+        return None
+
     def get_provider_rfsim_information(self, relation: Optional[Relation] = None
     ) -> Optional[ProviderAppData]:
         """Get relation data for the remote application.
@@ -295,6 +462,17 @@ class RFSIMRequires(Object):
 
         try:
             remote_app_relation_data["sst"] = int(remote_app_relation_data.get("sst", ""))
+            remote_app_relation_data["band"] = int(remote_app_relation_data.get("band", ""))
+            remote_app_relation_data["dl_freq"] = int(remote_app_relation_data.get("dl_freq", ""))
+            remote_app_relation_data["carrier_bandwidth"] = int(
+                remote_app_relation_data.get("carrier_bandwidth", "")
+            )
+            remote_app_relation_data["numerology"] = int(
+                remote_app_relation_data.get("numerology", "")
+            )
+            remote_app_relation_data["start_subcarrier"] = int(
+                remote_app_relation_data.get("start_subcarrier", "")
+            )
         except ValueError as err:
             logger.error("Invalid relation data: %s: %s", remote_app_relation_data, str(err))
             return None

--- a/lib/charms/oai_ran_du_k8s/v0/fiveg_rfsim.py
+++ b/lib/charms/oai_ran_du_k8s/v0/fiveg_rfsim.py
@@ -349,8 +349,15 @@ class RFSIMRequires(Object):
         self.relation_name = relation_name
 
     @property
-    def interface_version(self):
-        return LIBAPI
+    def provider_interface_version(self) -> Optional[int]:
+        """Return interface version used by the provider.
+
+        Returns:
+            Optional[int]: The `fiveg_rfsim` interface version used by the provider.
+        """
+        if remote_app_relation_data := self.get_provider_rfsim_information():
+            return remote_app_relation_data.version
+        return None
 
     @property
     def rfsim_address(self) -> Optional[IPvAnyAddress]:
@@ -462,6 +469,7 @@ class RFSIMRequires(Object):
         remote_app_relation_data: Dict[str, Any] = dict(relation.data[relation.app])
 
         try:
+            remote_app_relation_data["version"] = int(remote_app_relation_data.get("version", ""))
             remote_app_relation_data["sst"] = int(remote_app_relation_data.get("sst", ""))
             remote_app_relation_data["band"] = int(remote_app_relation_data.get("band", ""))
             remote_app_relation_data["dl_freq"] = int(remote_app_relation_data.get("dl_freq", ""))

--- a/lib/charms/oai_ran_du_k8s/v0/fiveg_rfsim.py
+++ b/lib/charms/oai_ran_du_k8s/v0/fiveg_rfsim.py
@@ -21,7 +21,7 @@ Add the following libraries to the charm's `requirements.txt` file:
 - pytest-interface-tester
 
 ### Provider charm
-The provider charm is the one providing the information about RF SIM address, SST, SD, RF band, downlink frequency, carrier bandwidth, numerology and the numer of the first usable subcarrier.
+The provider charm is the one providing the information about RF SIM address, SST, SD, RF band, downlink frequency, carrier bandwidth, numerology and the number of the first usable subcarrier.
 Typically, this will be the DU charm.
 
 Example:
@@ -97,7 +97,7 @@ class DummyFivegRFSIMRequires(CharmBase):
     def _on_fiveg_rfsim_relation_changed(self, event: RelationChangedEvent):
         provider_rfsim_address = event.rfsim_address
         provider_sst = event.sst
-        provider_st = event.sd
+        provider_sd = event.sd
         provider_band = event.band
         provider_dl_freq = event.dl_freq
         provider_carrier_bandwidth = event.carrier_bandwidth

--- a/lib/charms/oai_ran_du_k8s/v0/fiveg_rfsim.py
+++ b/lib/charms/oai_ran_du_k8s/v0/fiveg_rfsim.py
@@ -355,9 +355,7 @@ class RFSIMRequires(Object):
         Returns:
             Optional[int]: The `fiveg_rfsim` interface version used by the provider.
         """
-        if remote_app_relation_data := self.get_provider_rfsim_information():
-            return remote_app_relation_data.version
-        return None
+        return self._get_provider_interface_version()
 
     @property
     def rfsim_address(self) -> Optional[IPvAnyAddress]:
@@ -447,6 +445,21 @@ class RFSIMRequires(Object):
             return remote_app_relation_data.start_subcarrier
         return None
 
+    def _get_provider_interface_version(self) -> Optional[int]:
+        """Get provider interface version.
+
+        Returns:
+            Optional[int]: The `fiveg_rfsim` interface version used by the provider.
+        """
+        relation = self.model.get_relation(self.relation_name)
+        if not relation:
+            logger.error("No relation: %s", self.relation_name)
+            return None
+        if not relation.app:
+            logger.warning("No remote application in relation: %s", self.relation_name)
+            return None
+        return int(dict(relation.data[relation.app]).get("version", ""))
+
     def get_provider_rfsim_information(
         self, relation: Optional[Relation] = None
     ) -> Optional[ProviderAppData]:
@@ -469,7 +482,6 @@ class RFSIMRequires(Object):
         remote_app_relation_data: Dict[str, Any] = dict(relation.data[relation.app])
 
         try:
-            remote_app_relation_data["version"] = int(remote_app_relation_data.get("version", ""))
             remote_app_relation_data["sst"] = int(remote_app_relation_data.get("sst", ""))
             remote_app_relation_data["band"] = int(remote_app_relation_data.get("band", ""))
             remote_app_relation_data["dl_freq"] = int(remote_app_relation_data.get("dl_freq", ""))

--- a/src/charm.py
+++ b/src/charm.py
@@ -650,8 +650,8 @@ def _get_offset_to_point_a(
 
     Returns:
         int: Frequency-domain difference between the PointA and the first Resource Block (RB)
-             overlapping with the SSB block expressed as a number RBs with 15 kHz subcarrier
-             spacing.
+             overlapping with the SSB block. Parameter is expressed as a number RBs with 15 kHz
+             subcarrier spacing.
     """
     absolute_diff_int = int(absolute_frequency_ssb - dl_absolute_frequency_point_a)
     scaling_5khz = 3 if dl_absolute_frequency_point_a < ARFCN(600000) else 1

--- a/src/charm.py
+++ b/src/charm.py
@@ -9,7 +9,7 @@ import logging
 from functools import lru_cache
 from ipaddress import IPv4Address
 from subprocess import check_output
-from typing import List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from charms.kubernetes_charm_libraries.v0.multus import (
     KubernetesMultusCharmLib,
@@ -215,6 +215,15 @@ class OAIRANDUOperator(CharmBase):
             return
         if not self._relation_created(RFSIM_RELATION_NAME):
             return
+        if (
+            self._get_fiveg_rfsim_requirer_interface_version()
+            != self.rfsim_provider.interface_version
+        ):
+            logger.error(
+                "Can't establish communication over the `fiveg_rfsim` interface "
+                "due to version mismatch!"
+            )
+            return
         if not self._du_service_is_running():
             return
         if not self._get_rfsim_address():
@@ -229,10 +238,39 @@ class OAIRANDUOperator(CharmBase):
         if not remote_network_information.plmns:
             return
         self.rfsim_provider.set_rfsim_information(
-            self._get_rfsim_address(),
-            remote_network_information.plmns[0].sst,
-            remote_network_information.plmns[0].sd,
+            rfsim_address=self._get_rfsim_address(),
+            sst=remote_network_information.plmns[0].sst,
+            sd=remote_network_information.plmns[0].sd,
+            band=self._charm_config.frequency_band,
+            dl_freq=int(
+                get_dl_absolute_frequency_point_a(
+                    self._charm_config.center_frequency,
+                    self._charm_config.bandwidth,
+                    self._charm_config.sub_carrier_spacing,
+                ).to_frequency()
+            ),
+            carrier_bandwidth=self._get_carrier_bandwidth(),
+            numerology=_get_numerology(self._charm_config.sub_carrier_spacing),
+            start_subcarrier=_get_first_usable_subcarrier(
+                get_absolute_frequency_ssb(self._charm_config.center_frequency),
+                get_dl_absolute_frequency_point_a(
+                    self._charm_config.center_frequency,
+                    self._charm_config.bandwidth,
+                    self._charm_config.sub_carrier_spacing,
+                ),
+                _get_numerology(self._charm_config.sub_carrier_spacing),
+            ),
         )
+
+    def _get_fiveg_rfsim_requirer_interface_version(self) -> Optional[int]:
+        relation = self.model.get_relation(RFSIM_RELATION_NAME)
+        if not relation:
+            return None
+        fiveg_rfsim_requirer_app_data: Dict[str, Any] = dict(relation.data[relation.app])
+        try:
+            return int(fiveg_rfsim_requirer_app_data.get("version", ""))
+        except ValueError:
+            return None
 
     @staticmethod
     def _get_rfsim_address() -> str:
@@ -567,6 +605,68 @@ def _get_numerology(sub_carrier_spacing: Frequency) -> int:
     if sub_carrier_spacing in scs_to_numerology:
         return scs_to_numerology[sub_carrier_spacing]
     raise ValueError(f"Unsupported sub-carrier spacing: {sub_carrier_spacing}")
+
+
+def _get_first_usable_subcarrier(
+    absolute_frequency_ssb: ARFCN, dl_absolute_frequency_point_a: ARFCN, numerology: int
+) -> int:
+    """Calculate first usable subcarrier.
+
+    In this implementation only FR1 is supported.
+
+    Args:
+        absolute_frequency_ssb (ARFCN): Frequency-domain position of the SSB
+        dl_absolute_frequency_point_a (ARFCN): Frequency-domain position of Point A in Downlink
+        numerology (int): Numerology
+    """
+    ssb_offset_point_a = _get_ssb_offset_pointa(
+        absolute_frequency_ssb, dl_absolute_frequency_point_a, numerology
+    )
+    prb_offset = ssb_offset_point_a >> numerology
+    ssb_subcarrier_offset = _get_ssb_subcarrier_offset(
+        absolute_frequency_ssb,
+        dl_absolute_frequency_point_a,
+        numerology,
+    )
+    sc_offset = ssb_subcarrier_offset >> numerology
+    return 12 * prb_offset + sc_offset
+
+
+def _get_ssb_offset_pointa(
+    absolute_frequency_ssb: ARFCN, dl_absolute_frequency_point_a: ARFCN, numerology: int
+) -> int:
+    """Calculate ssbOffsetPointA.
+
+    In this implementation only FR1 is supported.
+
+    Args:
+        absolute_frequency_ssb (ARFCN): Frequency-domain position of the SSB
+        dl_absolute_frequency_point_a (ARFCN): Frequency-domain position of Point A in Downlink
+        numerology (int): Numerology
+    """
+    absolute_diff_int = int(absolute_frequency_ssb - dl_absolute_frequency_point_a)
+    scaling_5khz = 3 if dl_absolute_frequency_point_a < ARFCN(600000) else 1
+    scaling = 1 << numerology
+    scaled_absolute_diff = absolute_diff_int / (scaling_5khz * scaling)
+    return int(((scaled_absolute_diff / 12) - 10) * scaling)
+
+
+def _get_ssb_subcarrier_offset(
+    absolute_frequency_ssb: ARFCN, dl_absolute_frequency_point_a: ARFCN, numerology: int
+) -> int:
+    """Calculate ssbSubcarrierOffset.
+
+    In this implementation only FR1 is supported.
+
+    Args:
+        absolute_frequency_ssb (ARFCN): Frequency-domain position of the SSB
+        dl_absolute_frequency_point_a (ARFCN): Frequency-domain position of Point A in Downlink
+        numerology (int): Numerology
+    """
+    absolute_diff = int(absolute_frequency_ssb - dl_absolute_frequency_point_a)
+    scaling = 3 if dl_absolute_frequency_point_a < ARFCN(600000) else 1
+    sco_limit = 24 if numerology == 1 else 12
+    return int((absolute_diff / scaling) % sco_limit)
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/src/charm.py
+++ b/src/charm.py
@@ -618,24 +618,28 @@ def _get_first_usable_subcarrier(
         absolute_frequency_ssb (ARFCN): Frequency-domain position of the SSB
         dl_absolute_frequency_point_a (ARFCN): Frequency-domain position of Point A in Downlink
         numerology (int): Numerology
+
+    Returns:
+        int: Index of the first subcarrier of the SSB block assuming 15 kHz subcarrier spacing
+             in relation to PointA.
     """
-    ssb_offset_point_a = _get_ssb_offset_pointa(
+    offset_to_point_a = _get_offset_to_point_a(
         absolute_frequency_ssb, dl_absolute_frequency_point_a, numerology
     )
-    prb_offset = ssb_offset_point_a >> numerology
-    ssb_subcarrier_offset = _get_ssb_subcarrier_offset(
+    prb_offset = offset_to_point_a >> numerology
+    kssb = _get_kssb(
         absolute_frequency_ssb,
         dl_absolute_frequency_point_a,
         numerology,
     )
-    sc_offset = ssb_subcarrier_offset >> numerology
+    sc_offset = kssb >> numerology
     return 12 * prb_offset + sc_offset
 
 
-def _get_ssb_offset_pointa(
+def _get_offset_to_point_a(
     absolute_frequency_ssb: ARFCN, dl_absolute_frequency_point_a: ARFCN, numerology: int
 ) -> int:
-    """Calculate ssbOffsetPointA.
+    """Calculate OffsetToPointA.
 
     In this implementation only FR1 is supported.
 
@@ -643,6 +647,11 @@ def _get_ssb_offset_pointa(
         absolute_frequency_ssb (ARFCN): Frequency-domain position of the SSB
         dl_absolute_frequency_point_a (ARFCN): Frequency-domain position of Point A in Downlink
         numerology (int): Numerology
+
+    Returns:
+        int: Frequency-domain difference between the PointA and the first Resource Block (RB)
+             overlapping with the SSB block expressed as a number RBs with 15 kHz subcarrier
+             spacing.
     """
     absolute_diff_int = int(absolute_frequency_ssb - dl_absolute_frequency_point_a)
     scaling_5khz = 3 if dl_absolute_frequency_point_a < ARFCN(600000) else 1
@@ -651,10 +660,10 @@ def _get_ssb_offset_pointa(
     return int(((scaled_absolute_diff / 12) - 10) * scaling)
 
 
-def _get_ssb_subcarrier_offset(
+def _get_kssb(
     absolute_frequency_ssb: ARFCN, dl_absolute_frequency_point_a: ARFCN, numerology: int
 ) -> int:
-    """Calculate ssbSubcarrierOffset.
+    """Calculate kSSB.
 
     In this implementation only FR1 is supported.
 
@@ -662,6 +671,10 @@ def _get_ssb_subcarrier_offset(
         absolute_frequency_ssb (ARFCN): Frequency-domain position of the SSB
         dl_absolute_frequency_point_a (ARFCN): Frequency-domain position of Point A in Downlink
         numerology (int): Numerology
+
+    Returns:
+        int: Index of the first subcarrier of an SSB block within the first Resource Block
+             overlapping with the SSB block.
     """
     absolute_diff = int(absolute_frequency_ssb - dl_absolute_frequency_point_a)
     scaling = 3 if dl_absolute_frequency_point_a < ARFCN(600000) else 1

--- a/src/charm.py
+++ b/src/charm.py
@@ -673,8 +673,9 @@ def _get_kssb(
         numerology (int): Numerology
 
     Returns:
-        int: Index of the first subcarrier of an SSB block within the first Resource Block
-             overlapping with the SSB block.
+        int: Offset to the first subcarrier of an SSB block within the first Resource Block
+             overlapping with the SSB block. Parameter expressed as a number of subcarriers
+             assuming 15 kHz subcarrier spacing.
     """
     absolute_diff = int(absolute_frequency_ssb - dl_absolute_frequency_point_a)
     scaling = 3 if dl_absolute_frequency_point_a < ARFCN(600000) else 1

--- a/src/du_parameters/frequency.py
+++ b/src/du_parameters/frequency.py
@@ -6,11 +6,10 @@
 Handle arithmetic operations with different types of objects.
 """
 
-import decimal
 import logging
 from dataclasses import dataclass
-from decimal import Decimal
-from typing import Any
+from decimal import Decimal, InvalidOperation
+from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +25,12 @@ class GetRangeFromFrequencyError(Exception):
 
 class GetRangeFromGSCNError(Exception):
     """Exception raised when GSCN is not appropriate for any frequency range."""
+
+    pass
+
+
+class ARFCNError(Exception):
+    """Exception raised when a ARFCN to Frequency conversion fails."""
 
     pass
 
@@ -72,7 +77,7 @@ class Frequency(Decimal):
             raise TypeError("Float values are not supported, please use str instead.")
         try:
             return Frequency(super().__add__(Decimal(other)))
-        except (ValueError, TypeError, decimal.InvalidOperation) as e:
+        except (ValueError, TypeError, InvalidOperation) as e:
             raise NotImplementedError(f"Unsupported type for addition: {type(other)}") from e
 
     def __sub__(self, other: Any) -> "Frequency":
@@ -92,7 +97,7 @@ class Frequency(Decimal):
             raise TypeError("Float values are not supported, please use str instead.")
         try:
             return Frequency(super().__sub__(Decimal(other)))
-        except (ValueError, TypeError, decimal.InvalidOperation) as e:
+        except (ValueError, TypeError, InvalidOperation) as e:
             raise NotImplementedError(f"Unsupported type for subtraction: {type(other)}") from e
 
     def __rsub__(self, other: Any) -> "Frequency":
@@ -112,7 +117,7 @@ class Frequency(Decimal):
             raise TypeError("Float values are not supported, please use str instead.")
         try:
             return Frequency(super().__rsub__(Decimal(other)))
-        except (ValueError, TypeError, decimal.InvalidOperation) as e:
+        except (ValueError, TypeError, InvalidOperation) as e:
             raise NotImplementedError(f"Unsupported type for subtraction: {type(other)}") from e
 
     def __mul__(self, other: Any) -> "Frequency":
@@ -132,7 +137,7 @@ class Frequency(Decimal):
             raise TypeError("Float values are not supported, please use str instead.")
         try:
             return Frequency(super().__mul__(Decimal(other)))
-        except (ValueError, TypeError, decimal.InvalidOperation) as e:
+        except (ValueError, TypeError, InvalidOperation) as e:
             raise NotImplementedError(f"Unsupported type for multiplication: {type(other)}") from e
 
     def __truediv__(self, other: Any) -> "Frequency":
@@ -152,7 +157,7 @@ class Frequency(Decimal):
             raise TypeError("Float values are not supported, please use str instead.")
         try:
             return Frequency(super().__truediv__(Decimal(other)))
-        except (ValueError, TypeError, decimal.InvalidOperation) as e:
+        except (ValueError, TypeError, InvalidOperation) as e:
             raise NotImplementedError(f"Unsupported type for division: {type(other)}") from e
 
     def __repr__(self) -> str:
@@ -198,6 +203,28 @@ class ARFCN:
         """Return the ARFCN as a string."""
         return str(self._channel)
 
+    def __int__(self) -> int:
+        """Return the ARFCN as an integer."""
+        return self._channel
+
+    def __mul__(self, other: Any) -> "ARFCN":
+        """Multiply ARFCN by other ARFCN or integer.
+
+        Args:
+            other (Any): The value to multiply by.
+
+        Returns:
+            ARFCN: A new ARFCN instance with the updated channel.
+
+        Raises:
+            NotImplementedError: If the other value is not an ARFCN or int or Decimal.
+        """
+        if isinstance(other, ARFCN):
+            return ARFCN(self._channel * other._channel)  # type: ignore[operator]
+        if isinstance(other, int | Decimal):
+            return ARFCN(round(self._channel * other))  # type: ignore[operator]
+        raise NotImplementedError(f"Unsupported type for multiplication: {type(other).__name__}")
+
     def __add__(self, other: Any) -> "ARFCN":
         """Add another ARFCN or integer to this ARFCN.
 
@@ -216,6 +243,24 @@ class ARFCN:
             return ARFCN(round(self._channel + other))  # type: ignore[operator]
         raise NotImplementedError(f"Unsupported type for addition: {type(other).__name__}")
 
+    def __sub__(self, other: Any) -> "ARFCN":
+        """Subtract another ARFCN or integer from this ARFCN.
+
+        Args:
+            other (Any): The value to subtract.
+
+        Returns:
+            ARFCN: A new ARFCN instance with the updated channel.
+
+        Raises:
+            NotImplementedError: If the other value is not an ARFCN or int or Decimal.
+        """
+        if isinstance(other, ARFCN):
+            return ARFCN(self._channel - other._channel)  # type: ignore[operator]
+        if isinstance(other, int | Decimal):
+            return ARFCN(round(self._channel - other))  # type: ignore[operator]
+        raise NotImplementedError(f"Unsupported type for subtraction: {type(other).__name__}")
+
     def __eq__(self, other: Any) -> bool:
         """Check if ARFCN instance and other are equal.
 
@@ -229,6 +274,70 @@ class ARFCN:
             return other == self._channel
         if isinstance(other, ARFCN):
             return other._channel == self._channel
+        return False
+
+    def __le__(self, other: Any) -> bool:
+        """Check if ARFCN is lower than or equal to other ARFCN or integer.
+
+        Args:
+            other (Any): The value to compare with.
+
+        Returns:
+            bool: If the ARFCN instance is lower than or equal to other ARFCN or integer
+                  return True, else False.
+        """
+        if isinstance(other, int | Decimal):
+            return self._channel <= other
+        if isinstance(other, ARFCN):
+            return self._channel <= other._channel
+        return False
+
+    def __lt__(self, other: Any) -> bool:
+        """Check if ARFCN is lower than other ARFCN or integer.
+
+        Args:
+            other (Any): The value to compare with.
+
+        Returns:
+            bool: If the ARFCN instance is lower than other ARFCN or integer return True,
+                  else False.
+        """
+        if isinstance(other, int | Decimal):
+            return self._channel < other
+        if isinstance(other, ARFCN):
+            return self._channel < other._channel
+        return False
+
+    def __ge__(self, other: Any) -> bool:
+        """Check if ARFCN is grater than or equal to other ARFCN or integer.
+
+        Args:
+            other (Any): The value to compare with.
+
+        Returns:
+            bool: If the ARFCN instance is grater than or equal to other ARFCN or integer
+                  return True, else False.
+        """
+        if isinstance(other, int | Decimal):
+            return self._channel >= other
+        if isinstance(other, ARFCN):
+            return self._channel >= other._channel
+        return False
+
+    def __gt__(self, other: Any) -> bool:
+        """Check if ARFCN is grater than other ARFCN or integer.
+
+        Args:
+            other (Any): The value to compare with.
+
+        Returns:
+            bool: If the ARFCN instance is grater than other ARFCN or integer return True,
+                  else False.
+        """
+        if isinstance(other, int | Decimal):
+            return self._channel > other
+        if isinstance(other, ARFCN):
+            return self._channel > other._channel
         return False
 
     @classmethod
@@ -260,6 +369,18 @@ class ARFCN:
         logger.debug("Found ARFCN: %s for frequency: %s.", result, frequency)
         return result
 
+    def to_frequency(self) -> Frequency:
+        """Calculate the frequency based on ARFCN.
+
+        Returns:
+            frequency (Frequency): The closest frequency.
+        """
+        if config := get_range_from_arfcn(self):
+            return config.base_freq + config.freq_grid * int(self - config.arfcn_offset)
+
+        logger.error("Unable to calculate frequency for ARFCN %s", self)
+        raise ARFCNError(f"Unable to calculate frequency for ARFCN %s {self}")
+
 
 class GSCN:
     """Represent a Global Synchronization Channel Number (GSCN) used in 5G.
@@ -274,6 +395,8 @@ class GSCN:
         TypeError: If the channel is not an integer.
     """
 
+    # Fixme: According to the TS 38.101-1, the MIN_VALUE of GSCN is 2.
+    #  Changing the value here breaks the GSCN offset (base_gscn) for LOW_FREQUENCY though.
     MIN_VALUE = 0
     MAX_VALUE = 26639
 
@@ -397,17 +520,13 @@ class GSCN:
         raise NotImplementedError(f"Unsupported type for division: {type(other).__name__}")
 
     def to_frequency(self) -> Frequency:
-        """Calculate the frequency using input GSCN.
-
-        Args:
-           gscn (GSCN): The input GSCN.
+        """Calculate the frequency based on GSCN.
 
         Returns:
             frequency (Frequency): The closest frequency.
 
         Raises:
             ValueError: If the GSCN is out of supported range or n is out of range.
-            TypeError: If the input is not a GSCN.
         """
         try:
             config = get_range_from_gscn(self)
@@ -448,8 +567,8 @@ class GSCN:
                 f"Value of N: {n} is out of supported range ({config.min_n}-{config.max_n})."
             )
 
-        logger.error("Given configuration: %s is not supported.", config.name)
-        raise GSCNError(f"Unsupported configuration name: {config.name}")
+        logger.error("Given frequency range name: %s is not supported.", config.name)
+        raise GSCNError(f"Unsupported frequency range name: {config.name}")
 
     @classmethod
     def from_frequency(cls, frequency: Frequency) -> "GSCN":
@@ -504,8 +623,8 @@ class GSCN:
                 f"Value of N: {n} is out of supported range ({config.min_n}-{config.max_n})."
             )
 
-        logger.error("Given configuration: %s is not supported.", config.name)
-        raise GSCNError(f"Unsupported configuration name: {config.name}")
+        logger.error("Given frequency range name: %s is not supported.", config.name)
+        raise GSCNError(f"Unsupported frequency range name: {config.name}")
 
 
 @dataclass
@@ -598,6 +717,35 @@ def get_range_from_frequency(frequency: Frequency) -> FrequencyRange:
 
     logger.error("Frequency: %s is out of supported range.", frequency)
     raise GetRangeFromFrequencyError(f"Frequency {frequency} is out of supported range.")
+
+
+def get_range_from_arfcn(arfcn: ARFCN) -> Optional[FrequencyRange]:
+    """Return the appropriate frequency range configuration based on ARFCN.
+
+    Args:
+        arfcn: ARFCN instance
+
+    Returns:
+        FrequencyRange: Frequency range configuration if ARFCN is within the range.
+
+    Raises:
+        TypeError: If arfcn argument is not an instance of ARFCN.
+    """
+    if not isinstance(arfcn, ARFCN):
+        logger.error("Expected ARFCN but got: %s.", type(arfcn).__name__)
+        raise TypeError(f"Expected ARFCN, got {type(arfcn).__name__}")
+
+    if ARFCN(ARFCN.MIN_VALUE) <= arfcn <= ARFCN(599999):
+        logger.debug("Found frequency range configuration: LowFrequency.")
+        return LOW_FREQUENCY
+
+    if ARFCN(600000) <= arfcn <= ARFCN(2016666):
+        logger.debug("Found frequency range configuration: MidFrequency.")
+        return MID_FREQUENCY
+
+    if ARFCN(2016667) <= arfcn <= ARFCN(ARFCN.MAX_VALUE):
+        logger.debug("Found frequency range configuration: HighFrequency.")
+        return HIGH_FREQUENCY
 
 
 def get_range_from_gscn(gscn: GSCN) -> FrequencyRange:

--- a/src/du_parameters/frequency.py
+++ b/src/du_parameters/frequency.py
@@ -309,13 +309,13 @@ class ARFCN:
         return False
 
     def __ge__(self, other: Any) -> bool:
-        """Check if ARFCN is grater than or equal to other ARFCN or integer.
+        """Check if ARFCN is greater than or equal to other ARFCN or integer.
 
         Args:
             other (Any): The value to compare with.
 
         Returns:
-            bool: If the ARFCN instance is grater than or equal to other ARFCN or integer
+            bool: If the ARFCN instance is greater than or equal to other ARFCN or integer
                   return True, else False.
         """
         if isinstance(other, int | Decimal):
@@ -325,13 +325,13 @@ class ARFCN:
         return False
 
     def __gt__(self, other: Any) -> bool:
-        """Check if ARFCN is grater than other ARFCN or integer.
+        """Check if ARFCN is greater than other ARFCN or integer.
 
         Args:
             other (Any): The value to compare with.
 
         Returns:
-            bool: If the ARFCN instance is grater than other ARFCN or integer return True,
+            bool: If the ARFCN instance is greater than other ARFCN or integer return True,
                   else False.
         """
         if isinstance(other, int | Decimal):

--- a/tests/unit/lib/charms/oai_ran_du/v0/test_charms/test_provider_charm/src/charm.py
+++ b/tests/unit/lib/charms/oai_ran_du/v0/test_charms/test_provider_charm/src/charm.py
@@ -25,20 +25,20 @@ class DummyFivegRFSIMProviderCharm(CharmBase):
         rfsim_address = event.params.get("rfsim_address", "")
         sst = event.params.get("sst", "")
         sd = event.params.get("sd", "")
+        band = event.params.get("band", "")
+        dl_freq = event.params.get("dl_freq", "")
+        carrier_bandwidth = event.params.get("carrier_bandwidth", "")
+        numerology = event.params.get("numerology", "")
+        start_subcarrier = event.params.get("start_subcarrier", "")
         self.rfsim_provider.set_rfsim_information(
             rfsim_address=rfsim_address,
             sst=int(sst),
             sd=int(sd) if sd else None,
-        )
-
-    def _on_set_rfsim_information_as_string_action(self, event: ActionEvent):
-        rfsim_address = event.params.get("rfsim_address", "")
-        sst = event.params.get("sst", "")
-        sd = event.params.get("sd", "")
-        self.rfsim_provider.set_rfsim_information(
-            rfsim_address=rfsim_address,
-            sst=sst,
-            sd=sd if sd else None,
+            band=int(band),
+            dl_freq=int(dl_freq),
+            carrier_bandwidth=int(carrier_bandwidth),
+            numerology=int(numerology),
+            start_subcarrier=int(start_subcarrier),
         )
 
 

--- a/tests/unit/lib/charms/oai_ran_du/v0/test_charms/test_requirer_charm/src/charm.py
+++ b/tests/unit/lib/charms/oai_ran_du/v0/test_charms/test_requirer_charm/src/charm.py
@@ -23,12 +23,24 @@ class DummyFivegRFSIMRequires(CharmBase):
         )
 
     def _on_get_rfsim_information_action(self, event: ActionEvent):
+        version = event.params.get("expected_version", "")
         rfsim_address = event.params.get("expected_rfsim_address", "")
         sst = event.params.get("expected_sst", "")
         sd = event.params.get("expected_sd", "")
+        band = event.params.get("expected_band", "")
+        dl_freq = event.params.get("expected_dl_freq", "")
+        carrier_bandwidth = event.params.get("expected_carrier_bandwidth", "")
+        numerology = event.params.get("expected_numerology", "")
+        start_subcarrier = event.params.get("expected_start_subcarrier", "")
         data = {
+            "version": version,
             "rfsim_address": rfsim_address,
             "sst": int(sst),
+            "band": int(band),
+            "dl_freq": int(dl_freq),
+            "carrier_bandwidth": int(carrier_bandwidth),
+            "numerology": int(numerology),
+            "start_subcarrier": int(start_subcarrier),
         }
         if sd:
             data["sd"] = int(sd)

--- a/tests/unit/lib/charms/oai_ran_du/v0/test_fiveg_rfsim_provider_interface.py
+++ b/tests/unit/lib/charms/oai_ran_du/v0/test_fiveg_rfsim_provider_interface.py
@@ -11,6 +11,11 @@ from tests.unit.lib.charms.oai_ran_du.v0.test_charms.test_provider_charm.src.cha
 VALID_RFSIM_ADDRESS = "192.168.70.130"
 VALID_SST = "1"
 VALID_SD = "1"
+VALID_BAND = "78"
+VALID_DL_FREQ = "4059090000"
+VALID_CARRIER_BANDWIDTH = "106"
+VALID_NUMEROLOGY = "1"
+VALID_START_SUBCARRIER = "541"
 
 
 class TestFivegRFSIMProvides:
@@ -28,6 +33,11 @@ class TestFivegRFSIMProvides:
                         "rfsim_address": {"type": "string"},
                         "sst": {"type": "string"},
                         "sd": {"type": "string"},
+                        "band": {"type": "string"},
+                        "dl_freq": {"type": "string"},
+                        "carrier_bandwidth": {"type": "string"},
+                        "numerology": {"type": "string"},
+                        "start_subcarrier": {"type": "string"},
                     }
                 },
                 "set-rfsim-information-as-string": {
@@ -35,6 +45,11 @@ class TestFivegRFSIMProvides:
                         "rfsim_address": {"type": "string"},
                         "sst": {"type": "string"},
                         "sd": {"type": "string"},
+                        "band": {"type": "string"},
+                        "dl_freq": {"type": "string"},
+                        "carrier_bandwidth": {"type": "string"},
+                        "numerology": {"type": "string"},
+                        "start_subcarrier": {"type": "string"},
                     }
                 },
             },
@@ -55,6 +70,11 @@ class TestFivegRFSIMProvides:
             "rfsim_address": VALID_RFSIM_ADDRESS,
             "sst": VALID_SST,
             "sd": VALID_SD,
+            "band": VALID_BAND,
+            "dl_freq": VALID_DL_FREQ,
+            "carrier_bandwidth": VALID_CARRIER_BANDWIDTH,
+            "numerology": VALID_NUMEROLOGY,
+            "start_subcarrier": VALID_START_SUBCARRIER,
         }
 
         state_out = self.ctx.run(
@@ -65,6 +85,11 @@ class TestFivegRFSIMProvides:
         assert relation.local_app_data["rfsim_address"] == VALID_RFSIM_ADDRESS
         assert relation.local_app_data["sst"] == VALID_SST
         assert relation.local_app_data["sd"] == VALID_SD
+        assert relation.local_app_data["band"] == VALID_BAND
+        assert relation.local_app_data["dl_freq"] == VALID_DL_FREQ
+        assert relation.local_app_data["carrier_bandwidth"] == VALID_CARRIER_BANDWIDTH
+        assert relation.local_app_data["numerology"] == VALID_NUMEROLOGY
+        assert relation.local_app_data["start_subcarrier"] == VALID_START_SUBCARRIER
 
     def test_given_no_sd_when_set_rfsim_information_then_rfsim_data_is_pushed_to_the_relation_databag_without_sd(  # noqa: E501
         self,
@@ -80,6 +105,11 @@ class TestFivegRFSIMProvides:
         params = {
             "rfsim_address": VALID_RFSIM_ADDRESS,
             "sst": VALID_SST,
+            "band": VALID_BAND,
+            "dl_freq": VALID_DL_FREQ,
+            "carrier_bandwidth": VALID_CARRIER_BANDWIDTH,
+            "numerology": VALID_NUMEROLOGY,
+            "start_subcarrier": VALID_START_SUBCARRIER,
         }
 
         state_out = self.ctx.run(
@@ -90,6 +120,11 @@ class TestFivegRFSIMProvides:
         assert relation.local_app_data["rfsim_address"] == VALID_RFSIM_ADDRESS
         assert relation.local_app_data["sst"] == VALID_SST
         assert relation.local_app_data.get("sd") is None
+        assert relation.local_app_data["band"] == VALID_BAND
+        assert relation.local_app_data["dl_freq"] == VALID_DL_FREQ
+        assert relation.local_app_data["carrier_bandwidth"] == VALID_CARRIER_BANDWIDTH
+        assert relation.local_app_data["numerology"] == VALID_NUMEROLOGY
+        assert relation.local_app_data["start_subcarrier"] == VALID_START_SUBCARRIER
 
     @pytest.mark.parametrize(
         "rfsim_address",
@@ -113,6 +148,11 @@ class TestFivegRFSIMProvides:
             "rfsim_address": rfsim_address,
             "sst": VALID_SST,
             "sd": VALID_SD,
+            "band": VALID_BAND,
+            "dl_freq": VALID_DL_FREQ,
+            "carrier_bandwidth": VALID_CARRIER_BANDWIDTH,
+            "numerology": VALID_NUMEROLOGY,
+            "start_subcarrier": VALID_START_SUBCARRIER,
         }
 
         with pytest.raises(Exception) as e:
@@ -144,6 +184,170 @@ class TestFivegRFSIMProvides:
             "rfsim_address": VALID_RFSIM_ADDRESS,
             "sst": sst,
             "sd": sd,
+            "band": VALID_BAND,
+            "dl_freq": VALID_DL_FREQ,
+            "carrier_bandwidth": VALID_CARRIER_BANDWIDTH,
+            "numerology": VALID_NUMEROLOGY,
+            "start_subcarrier": VALID_START_SUBCARRIER,
+        }
+
+        with pytest.raises(Exception) as e:
+            self.ctx.run(self.ctx.on.action("set-rfsim-information", params=params), state_in)
+
+        assert "Invalid relation data" in str(e.value)
+
+    @pytest.mark.parametrize(
+        "band",
+        [
+            pytest.param("-1", id="rf_band_negative_numer"),
+            pytest.param("0", id="rf_band_is_0"),
+        ],
+    )
+    def test_given_invalid_rf_band_when_set_rfsim_information_then_error_is_raised(self, band):
+        fiveg_rfsim_relation = testing.Relation(
+            endpoint="fiveg_rfsim",
+            interface="fiveg_rfsim",
+        )
+        state_in = testing.State(
+            relations=[fiveg_rfsim_relation],
+            leader=True,
+        )
+        params = {
+            "rfsim_address": VALID_RFSIM_ADDRESS,
+            "sst": VALID_SST,
+            "sd": VALID_SD,
+            "band": band,
+            "dl_freq": VALID_DL_FREQ,
+            "carrier_bandwidth": VALID_CARRIER_BANDWIDTH,
+            "numerology": VALID_NUMEROLOGY,
+            "start_subcarrier": VALID_START_SUBCARRIER,
+        }
+
+        with pytest.raises(Exception) as e:
+            self.ctx.run(self.ctx.on.action("set-rfsim-information", params=params), state_in)
+
+        assert "Invalid relation data" in str(e.value)
+
+    @pytest.mark.parametrize(
+        "dl_freq",
+        [
+            pytest.param("-1", id="dl_freq_negative_numer"),
+            pytest.param("0", id="dl_freq_is_0"),
+            pytest.param("1234567", id="dl_freq_below_410_mhz"),
+        ],
+    )
+    def test_given_invalid_dl_freq_when_set_rfsim_information_then_error_is_raised(self, dl_freq):
+        fiveg_rfsim_relation = testing.Relation(
+            endpoint="fiveg_rfsim",
+            interface="fiveg_rfsim",
+        )
+        state_in = testing.State(
+            relations=[fiveg_rfsim_relation],
+            leader=True,
+        )
+        params = {
+            "rfsim_address": VALID_RFSIM_ADDRESS,
+            "sst": VALID_SST,
+            "sd": VALID_SD,
+            "band": VALID_BAND,
+            "dl_freq": dl_freq,
+            "carrier_bandwidth": VALID_CARRIER_BANDWIDTH,
+            "numerology": VALID_NUMEROLOGY,
+            "start_subcarrier": VALID_START_SUBCARRIER,
+        }
+
+        with pytest.raises(Exception) as e:
+            self.ctx.run(self.ctx.on.action("set-rfsim-information", params=params), state_in)
+
+        assert "Invalid relation data" in str(e.value)
+
+    @pytest.mark.parametrize(
+        "carrier_bandwidth",
+        [
+            pytest.param("-1", id="carrier_bandwidth_negative_numer"),
+            pytest.param("10", id="carrier_bandwidth_below_11"),
+            pytest.param("274", id="carrier_bandwidth_above_273"),
+        ],
+    )
+    def test_given_invalid_carrier_bandwidth_when_set_rfsim_information_then_error_is_raised(
+        self, carrier_bandwidth
+    ):
+        fiveg_rfsim_relation = testing.Relation(
+            endpoint="fiveg_rfsim",
+            interface="fiveg_rfsim",
+        )
+        state_in = testing.State(
+            relations=[fiveg_rfsim_relation],
+            leader=True,
+        )
+        params = {
+            "rfsim_address": VALID_RFSIM_ADDRESS,
+            "sst": VALID_SST,
+            "sd": VALID_SD,
+            "band": VALID_BAND,
+            "dl_freq": VALID_DL_FREQ,
+            "carrier_bandwidth": carrier_bandwidth,
+            "numerology": VALID_NUMEROLOGY,
+            "start_subcarrier": VALID_START_SUBCARRIER,
+        }
+
+        with pytest.raises(Exception) as e:
+            self.ctx.run(self.ctx.on.action("set-rfsim-information", params=params), state_in)
+
+        assert "Invalid relation data" in str(e.value)
+
+    @pytest.mark.parametrize(
+        "numerology",
+        [
+            pytest.param("-1", id="numerology_negative_numer"),
+            pytest.param("7", id="numerology_above_6"),
+        ],
+    )
+    def test_given_invalid_numerology_when_set_rfsim_information_then_error_is_raised(
+        self, numerology
+    ):
+        fiveg_rfsim_relation = testing.Relation(
+            endpoint="fiveg_rfsim",
+            interface="fiveg_rfsim",
+        )
+        state_in = testing.State(
+            relations=[fiveg_rfsim_relation],
+            leader=True,
+        )
+        params = {
+            "rfsim_address": VALID_RFSIM_ADDRESS,
+            "sst": VALID_SST,
+            "sd": VALID_SD,
+            "band": VALID_BAND,
+            "dl_freq": VALID_DL_FREQ,
+            "carrier_bandwidth": VALID_CARRIER_BANDWIDTH,
+            "numerology": numerology,
+            "start_subcarrier": VALID_START_SUBCARRIER,
+        }
+
+        with pytest.raises(Exception) as e:
+            self.ctx.run(self.ctx.on.action("set-rfsim-information", params=params), state_in)
+
+        assert "Invalid relation data" in str(e.value)
+
+    def test_given_invalid_start_subcarrier_when_set_rfsim_information_then_error_is_raised(self):
+        fiveg_rfsim_relation = testing.Relation(
+            endpoint="fiveg_rfsim",
+            interface="fiveg_rfsim",
+        )
+        state_in = testing.State(
+            relations=[fiveg_rfsim_relation],
+            leader=True,
+        )
+        params = {
+            "rfsim_address": VALID_RFSIM_ADDRESS,
+            "sst": VALID_SST,
+            "sd": VALID_SD,
+            "band": VALID_BAND,
+            "dl_freq": VALID_DL_FREQ,
+            "carrier_bandwidth": VALID_CARRIER_BANDWIDTH,
+            "numerology": VALID_NUMEROLOGY,
+            "start_subcarrier": "-1",
         }
 
         with pytest.raises(Exception) as e:
@@ -166,6 +370,11 @@ class TestFivegRFSIMProvides:
             "rfsim_address": VALID_RFSIM_ADDRESS,
             "sst": VALID_SST,
             "sd": VALID_SD,
+            "band": VALID_BAND,
+            "dl_freq": VALID_DL_FREQ,
+            "carrier_bandwidth": VALID_CARRIER_BANDWIDTH,
+            "numerology": VALID_NUMEROLOGY,
+            "start_subcarrier": VALID_START_SUBCARRIER,
         }
 
         with pytest.raises(Exception) as e:
@@ -181,6 +390,11 @@ class TestFivegRFSIMProvides:
             "rfsim_address": VALID_RFSIM_ADDRESS,
             "sst": VALID_SST,
             "sd": VALID_SD,
+            "band": VALID_BAND,
+            "dl_freq": VALID_DL_FREQ,
+            "carrier_bandwidth": VALID_CARRIER_BANDWIDTH,
+            "numerology": VALID_NUMEROLOGY,
+            "start_subcarrier": VALID_START_SUBCARRIER,
         }
 
         with pytest.raises(Exception) as e:

--- a/tests/unit/lib/charms/oai_ran_du/v0/test_fiveg_rfsim_provider_interface.py
+++ b/tests/unit/lib/charms/oai_ran_du/v0/test_fiveg_rfsim_provider_interface.py
@@ -199,7 +199,7 @@ class TestFivegRFSIMProvides:
     @pytest.mark.parametrize(
         "band",
         [
-            pytest.param("-1", id="rf_band_negative_numer"),
+            pytest.param("-1", id="rf_band_negative_number"),
             pytest.param("0", id="rf_band_is_0"),
         ],
     )
@@ -231,9 +231,10 @@ class TestFivegRFSIMProvides:
     @pytest.mark.parametrize(
         "dl_freq",
         [
-            pytest.param("-1", id="dl_freq_negative_numer"),
+            pytest.param("-1", id="dl_freq_negative_number"),
             pytest.param("0", id="dl_freq_is_0"),
             pytest.param("1234567", id="dl_freq_below_410_mhz"),
+            pytest.param("409999999", id="dl_freq_upper_edge"),
         ],
     )
     def test_given_invalid_dl_freq_when_set_rfsim_information_then_error_is_raised(self, dl_freq):
@@ -264,7 +265,7 @@ class TestFivegRFSIMProvides:
     @pytest.mark.parametrize(
         "carrier_bandwidth",
         [
-            pytest.param("-1", id="carrier_bandwidth_negative_numer"),
+            pytest.param("-1", id="carrier_bandwidth_negative_number"),
             pytest.param("10", id="carrier_bandwidth_below_11"),
             pytest.param("274", id="carrier_bandwidth_above_273"),
         ],
@@ -299,7 +300,7 @@ class TestFivegRFSIMProvides:
     @pytest.mark.parametrize(
         "numerology",
         [
-            pytest.param("-1", id="numerology_negative_numer"),
+            pytest.param("-1", id="numerology_negative_number"),
             pytest.param("7", id="numerology_above_6"),
         ],
     )

--- a/tests/unit/lib/charms/oai_ran_du/v0/test_fiveg_rfsim_requirer_interface.py
+++ b/tests/unit/lib/charms/oai_ran_du/v0/test_fiveg_rfsim_requirer_interface.py
@@ -9,9 +9,15 @@ from tests.unit.lib.charms.oai_ran_du.v0.test_charms.test_requirer_charm.src.cha
     DummyFivegRFSIMRequires,
 )
 
+VALID_INTERFACE_VERSION = "0"
 VALID_RFSIM_ADDRESS = "192.168.70.130"
 VALID_SST = "1"
 VALID_SD = "1"
+VALID_BAND = "78"
+VALID_DL_FREQ = "4059090000"
+VALID_CARRIER_BANDWIDTH = "106"
+VALID_NUMEROLOGY = "1"
+VALID_START_SUBCARRIER = "541"
 
 
 class TestFivegRFSIMRequires:
@@ -26,9 +32,15 @@ class TestFivegRFSIMRequires:
             actions={
                 "get-rfsim-information": {
                     "params": {
+                        "expected_version": {"type": "integer"},
                         "expected_rfsim_address": {"type": "string"},
                         "expected_sst": {"type": "integer"},
                         "expected_sd": {"type": "integer"},
+                        "expected_band": {"type": "integer"},
+                        "expected_dl_freq": {"type": "integer"},
+                        "expected_carrier_bandwidth": {"type": "integer"},
+                        "expected_numerology": {"type": "integer"},
+                        "expected_start_subcarrier": {"type": "integer"},
                     }
                 },
                 "get-rfsim-information-invalid": {"params": {}},
@@ -36,33 +48,67 @@ class TestFivegRFSIMRequires:
         )
 
     @pytest.mark.parametrize(
-        "remote_data,expected_rfsim_address,expected_sst,expected_sd",
+        "remote_data,expected_version,expected_rfsim_address,expected_sst,expected_sd,expected_band,expected_dl_freq,expected_carrier_bandwidth,expected_numerology,expected_start_subcarrier",
         [
             pytest.param(
                 {
+                    "version": VALID_INTERFACE_VERSION,
                     "rfsim_address": VALID_RFSIM_ADDRESS,
                     "sst": VALID_SST,
                     "sd": VALID_SD,
+                    "band": VALID_BAND,
+                    "dl_freq": VALID_DL_FREQ,
+                    "carrier_bandwidth": VALID_CARRIER_BANDWIDTH,
+                    "numerology": VALID_NUMEROLOGY,
+                    "start_subcarrier": VALID_START_SUBCARRIER,
                 },
+                int(VALID_INTERFACE_VERSION),
                 VALID_RFSIM_ADDRESS,
                 int(VALID_SST),
                 int(VALID_SD),
+                int(VALID_BAND),
+                int(VALID_DL_FREQ),
+                int(VALID_CARRIER_BANDWIDTH),
+                int(VALID_NUMEROLOGY),
+                int(VALID_START_SUBCARRIER),
                 id="all_attributes_are_available",
             ),
             pytest.param(
                 {
+                    "version": VALID_INTERFACE_VERSION,
                     "rfsim_address": VALID_RFSIM_ADDRESS,
                     "sst": VALID_SST,
+                    "band": VALID_BAND,
+                    "dl_freq": VALID_DL_FREQ,
+                    "carrier_bandwidth": VALID_CARRIER_BANDWIDTH,
+                    "numerology": VALID_NUMEROLOGY,
+                    "start_subcarrier": VALID_START_SUBCARRIER,
                 },
+                int(VALID_INTERFACE_VERSION),
                 VALID_RFSIM_ADDRESS,
                 int(VALID_SST),
                 int(),
+                int(VALID_BAND),
+                int(VALID_DL_FREQ),
+                int(VALID_CARRIER_BANDWIDTH),
+                int(VALID_NUMEROLOGY),
+                int(VALID_START_SUBCARRIER),
                 id="empty_sd",
             ),
         ],
     )
     def test_given_valid_rfsim_information_in_relation_data_when_get_rfsim_information_is_called_then_information_is_returned(  # noqa: E501
-        self, remote_data, expected_rfsim_address, expected_sst, expected_sd
+        self,
+        remote_data,
+        expected_version,
+        expected_rfsim_address,
+        expected_sst,
+        expected_sd,
+        expected_band,
+        expected_dl_freq,
+        expected_carrier_bandwidth,
+        expected_numerology,
+        expected_start_subcarrier,
     ):
         fiveg_rfsim_relation = testing.Relation(
             endpoint="fiveg_rfsim",
@@ -74,9 +120,15 @@ class TestFivegRFSIMRequires:
             relations=[fiveg_rfsim_relation],
         )
         params = {
+            "expected_version": expected_version,
             "expected_rfsim_address": expected_rfsim_address,
             "expected_sst": expected_sst,
             "expected_sd": expected_sd,
+            "expected_band": expected_band,
+            "expected_dl_freq": expected_dl_freq,
+            "expected_carrier_bandwidth": expected_carrier_bandwidth,
+            "expected_numerology": expected_numerology,
+            "expected_start_subcarrier": expected_start_subcarrier,
         }
         self.ctx.run(self.ctx.on.action("get-rfsim-information", params=params), state_in)
 
@@ -85,19 +137,115 @@ class TestFivegRFSIMRequires:
         [
             pytest.param(
                 {
+                    "version": "-1",
                     "rfsim_address": "1111",
                     "sst": VALID_SST,
                     "sd": VALID_SD,
+                    "band": VALID_BAND,
+                    "dl_freq": VALID_DL_FREQ,
+                    "carrier_bandwidth": VALID_CARRIER_BANDWIDTH,
+                    "numerology": VALID_NUMEROLOGY,
+                    "start_subcarrier": VALID_START_SUBCARRIER,
+                },
+                id="invalid_interface_version",
+            ),
+            pytest.param(
+                {
+                    "version": VALID_INTERFACE_VERSION,
+                    "rfsim_address": "1111",
+                    "sst": VALID_SST,
+                    "sd": VALID_SD,
+                    "band": VALID_BAND,
+                    "dl_freq": VALID_DL_FREQ,
+                    "carrier_bandwidth": VALID_CARRIER_BANDWIDTH,
+                    "numerology": VALID_NUMEROLOGY,
+                    "start_subcarrier": VALID_START_SUBCARRIER,
                 },
                 id="invalid_rfsim_address",
             ),
             pytest.param(
                 {
+                    "version": VALID_INTERFACE_VERSION,
                     "rfsim_address": VALID_RFSIM_ADDRESS,
                     "sst": "",
                     "sd": VALID_SD,
+                    "band": VALID_BAND,
+                    "dl_freq": VALID_DL_FREQ,
+                    "carrier_bandwidth": VALID_CARRIER_BANDWIDTH,
+                    "numerology": VALID_NUMEROLOGY,
+                    "start_subcarrier": VALID_START_SUBCARRIER,
                 },
                 id="empty_sst",
+            ),
+            pytest.param(
+                {
+                    "version": VALID_INTERFACE_VERSION,
+                    "rfsim_address": VALID_RFSIM_ADDRESS,
+                    "sst": VALID_SST,
+                    "sd": VALID_SD,
+                    "band": "-1",
+                    "dl_freq": VALID_DL_FREQ,
+                    "carrier_bandwidth": VALID_CARRIER_BANDWIDTH,
+                    "numerology": VALID_NUMEROLOGY,
+                    "start_subcarrier": VALID_START_SUBCARRIER,
+                },
+                id="invalid_band",
+            ),
+            pytest.param(
+                {
+                    "version": VALID_INTERFACE_VERSION,
+                    "rfsim_address": VALID_RFSIM_ADDRESS,
+                    "sst": VALID_SST,
+                    "sd": VALID_SD,
+                    "band": VALID_BAND,
+                    "dl_freq": "-1",
+                    "carrier_bandwidth": VALID_CARRIER_BANDWIDTH,
+                    "numerology": VALID_NUMEROLOGY,
+                    "start_subcarrier": VALID_START_SUBCARRIER,
+                },
+                id="invalid_dl_freq",
+            ),
+            pytest.param(
+                {
+                    "version": VALID_INTERFACE_VERSION,
+                    "rfsim_address": VALID_RFSIM_ADDRESS,
+                    "sst": VALID_SST,
+                    "sd": VALID_SD,
+                    "band": VALID_BAND,
+                    "dl_freq": VALID_DL_FREQ,
+                    "carrier_bandwidth": "274",
+                    "numerology": VALID_NUMEROLOGY,
+                    "start_subcarrier": VALID_START_SUBCARRIER,
+                },
+                id="invalid_carrier_bandwidth",
+            ),
+            pytest.param(
+                {
+                    "version": VALID_INTERFACE_VERSION,
+                    "rfsim_address": VALID_RFSIM_ADDRESS,
+                    "sst": VALID_SST,
+                    "sd": VALID_SD,
+                    "band": VALID_BAND,
+                    "dl_freq": VALID_DL_FREQ,
+                    "carrier_bandwidth": VALID_CARRIER_BANDWIDTH,
+                    "numerology": "7",
+                    "start_subcarrier": VALID_START_SUBCARRIER,
+                },
+                id="invalid_numerology",
+            ),
+            pytest.param(
+                {
+                    "version": VALID_INTERFACE_VERSION,
+                    "rfsim_address": VALID_RFSIM_ADDRESS,
+                    "sst": VALID_SST,
+                    "sd": VALID_SD,
+                    "band": VALID_BAND,
+                    "dl_freq": VALID_DL_FREQ,
+                    "carrier_bandwidth": VALID_CARRIER_BANDWIDTH,
+                    "numerology": VALID_NUMEROLOGY,
+                    "start_subcarrier": "-1",
+                },
+                id="invalid_start_subcarrier",
             ),
         ],
     )

--- a/tests/unit/test_charm_fiveg_rfsim_relation_changed.py
+++ b/tests/unit/test_charm_fiveg_rfsim_relation_changed.py
@@ -4,10 +4,18 @@
 
 import tempfile
 
+from charms.oai_ran_du_k8s.v0.fiveg_rfsim import LIBAPI
 from ops import testing
 from ops.pebble import Layer, ServiceStatus
 
 from tests.unit.fixtures import F1_PROVIDER_DATA_WITH_SD, DUFixtures
+
+SAMPLE_CONFIG = {
+    "bandwidth": 20,
+    "frequency-band": 77,
+    "sub-carrier-spacing": 15,
+    "center-frequency": "3500",
+}
 
 
 class TestCharmFivegRFSIMRelationChanged(DUFixtures):
@@ -29,9 +37,10 @@ class TestCharmFivegRFSIMRelationChanged(DUFixtures):
         relation = state_out.get_relation(fiveg_rfsim_relation.id)
         assert relation.local_app_data == {}
 
-    def test_given_given_service_is_running_and_f1_relation_joined_and_remote_network_information_exists_when_fiveg_rfsim_relation_changed_then_rfsim_information_is_in_relation_databag(  # noqa: E501
+    def test_given_service_is_running_and_f1_relation_joined_and_remote_network_information_exists_when_fiveg_rfsim_relation_changed_then_rfsim_information_is_in_relation_databag(  # noqa: E501
         self,
     ):
+        DUFixtures.patcher_rfsim_provides_set_rfsim_information.stop()
         with tempfile.TemporaryDirectory() as temp_dir:
             self.mock_du_security_context.is_privileged.return_value = True
             self.mock_du_usb_volume.is_mounted.return_value = True
@@ -44,7 +53,7 @@ class TestCharmFivegRFSIMRelationChanged(DUFixtures):
             fiveg_rfsim_relation = testing.Relation(
                 endpoint="fiveg_rfsim",
                 interface="fiveg_rfsim",
-                local_app_data={"rfsim_address": "1.2.3.4", "sst": "1", "sd": "1"},
+                remote_app_data={"version": str(LIBAPI)},
             )
             config_mount = testing.Mount(
                 source=temp_dir,
@@ -77,22 +86,34 @@ class TestCharmFivegRFSIMRelationChanged(DUFixtures):
                 relations=[f1_relation, fiveg_rfsim_relation],
                 containers=[container],
                 model=testing.Model(name="whatever"),
-                config={"simulation-mode": True},
+                config={**SAMPLE_CONFIG, "simulation-mode": True},
             )
 
             state_out = self.ctx.run(self.ctx.on.relation_changed(fiveg_rfsim_relation), state_in)
             relation = state_out.get_relation(fiveg_rfsim_relation.id)
-            assert relation.local_app_data == {"rfsim_address": "1.2.3.4", "sst": "1", "sd": "1"}
+            assert relation.local_app_data == {
+                "version": str(LIBAPI),
+                "rfsim_address": "1.2.3.4",
+                "sst": "1",
+                "sd": "1",
+                "band": "77",
+                "dl_freq": "3490005000",
+                "carrier_bandwidth": "106",
+                "numerology": "0",
+                "start_subcarrier": "525",
+            }
 
     def test_given_given_service_is_running_and_f1_relation_does_not_exist_when_fiveg_rfsim_relation_changed_then_rfsim_information_is_not_in_relation_databag(  # noqa: E501
         self,
     ):
+        DUFixtures.patcher_rfsim_provides_set_rfsim_information.stop()
         with tempfile.TemporaryDirectory() as temp_dir:
             self.mock_du_security_context.is_privileged.return_value = True
             self.mock_check_output.return_value = b"1.2.3.4"
             fiveg_rfsim_relation = testing.Relation(
                 endpoint="fiveg_rfsim",
                 interface="fiveg_rfsim",
+                remote_app_data={"version": str(LIBAPI)},
             )
             config_mount = testing.Mount(
                 source=temp_dir,
@@ -125,7 +146,7 @@ class TestCharmFivegRFSIMRelationChanged(DUFixtures):
                 relations=[fiveg_rfsim_relation],
                 containers=[container],
                 model=testing.Model(name="whatever"),
-                config={"simulation-mode": True},
+                config={**SAMPLE_CONFIG, "simulation-mode": True},
             )
 
             state_out = self.ctx.run(self.ctx.on.relation_changed(fiveg_rfsim_relation), state_in)


### PR DESCRIPTION
# Description

Implements possibility of passing UE simulator startup params over the fiveg_rfsim relation.
All parameters required by the UE simulator are now taken directly from the DU config file or calculated based on the DU configuration and pushed to the `fiveg_rfsim` relation data bag.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library