### PR TITLE
fix: Resets fiveg_rfsim LIBPATCH to 1 to publish it

### DIFF
--- a/lib/charms/oai_ran_du_k8s/v0/fiveg_rfsim.py
+++ b/lib/charms/oai_ran_du_k8s/v0/fiveg_rfsim.py
@@ -131,7 +131,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 1
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
# Description

Resets `fiveg_rfsim` LIBPATCH to 1 to publish it.
This lib has never been published before and charmcraft refuses to publish it with LIBPATCH = 6. Hopefully resetting it to `1` will fix the issue.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library