### PR TITLE
chore: Adds fiveg_rfsim requirer method for setting the App relation data

### DIFF
--- a/lib/charms/oai_ran_du_k8s/v0/fiveg_rfsim.py
+++ b/lib/charms/oai_ran_du_k8s/v0/fiveg_rfsim.py
@@ -260,6 +260,23 @@ def provider_data_is_valid(data: Dict[str, Any]) -> bool:
         return False
 
 
+def requirer_data_is_valid(data: Dict[str, Any]) -> bool:
+    """Return whether the requirer data is valid.
+
+    Args:
+        data (dict): Data to be validated.
+
+    Returns:
+        bool: True if data is valid, False otherwise.
+    """
+    try:
+        RequirerSchema(app_data=RequirerAppData(**data))
+        return True
+    except ValidationError as e:
+        logger.error("Invalid data: %s", e)
+        return False
+
+
 class FivegRFSIMError(Exception):
     """Custom error class for the `fiveg_rfsim` library."""
 
@@ -515,3 +532,16 @@ class RFSIMRequires(Object):
             logger.error("Invalid relation data: %s: %s", remote_app_relation_data, str(err))
             return None
         return provider_app_data
+
+    def set_rfsim_information(self) -> None:
+        """Push the information about the `fiveg_rfsim` interface version used by the Requirer."""
+        if not self.charm.unit.is_leader():
+            raise FivegRFSIMError("Unit must be leader to set application relation data.")
+        relations = self.model.relations[self.relation_name]
+        if not relations:
+            raise FivegRFSIMError(f"Relation {self.relation_name} not created yet.")
+        if not requirer_data_is_valid({"version": str(LIBAPI)}):
+            raise FivegRFSIMError("Invalid relation data")
+        for relation in relations:
+            data = {"version": str(LIBAPI)}
+            relation.data[self.charm.app].update(data)

--- a/tests/unit/lib/charms/oai_ran_du/v0/test_charms/test_requirer_charm/src/charm.py
+++ b/tests/unit/lib/charms/oai_ran_du/v0/test_charms/test_requirer_charm/src/charm.py
@@ -57,6 +57,8 @@ class DummyFivegRFSIMRequires(CharmBase):
     def _on_set_rfsim_information_action(self, event: ActionEvent):
         self.rfsim_requirer.set_rfsim_information()
         relation = self.model.get_relation(self.rfsim_requirer.relation_name)
+        if not relation:
+            assert False
         assert int(relation.data[self.app].get("version", "")) == LIBAPI
 
 

--- a/tests/unit/lib/charms/oai_ran_du/v0/test_charms/test_requirer_charm/src/charm.py
+++ b/tests/unit/lib/charms/oai_ran_du/v0/test_charms/test_requirer_charm/src/charm.py
@@ -5,7 +5,7 @@
 from ops import main
 from ops.charm import ActionEvent, CharmBase
 
-from lib.charms.oai_ran_du_k8s.v0.fiveg_rfsim import ProviderAppData, RFSIMRequires
+from lib.charms.oai_ran_du_k8s.v0.fiveg_rfsim import LIBAPI, ProviderAppData, RFSIMRequires
 
 
 class DummyFivegRFSIMRequires(CharmBase):
@@ -20,6 +20,10 @@ class DummyFivegRFSIMRequires(CharmBase):
         self.framework.observe(
             self.on.get_rfsim_information_invalid_action,
             self._on_get_rfsim_information_invalid_action,
+        )
+        self.framework.observe(
+            self.on.set_rfsim_information_action,
+            self._on_set_rfsim_information_action,
         )
 
     def _on_get_rfsim_information_action(self, event: ActionEvent):
@@ -49,6 +53,11 @@ class DummyFivegRFSIMRequires(CharmBase):
 
     def _on_get_rfsim_information_invalid_action(self, event: ActionEvent):
         assert self.rfsim_requirer.get_provider_rfsim_information() is None
+
+    def _on_set_rfsim_information_action(self, event: ActionEvent):
+        self.rfsim_requirer.set_rfsim_information()
+        relation = self.model.get_relation(self.rfsim_requirer.relation_name)
+        assert int(relation.data[self.app].get("version", "")) == LIBAPI
 
 
 if __name__ == "__main__":

--- a/tests/unit/lib/charms/oai_ran_du/v0/test_fiveg_rfsim_requirer_interface.py
+++ b/tests/unit/lib/charms/oai_ran_du/v0/test_fiveg_rfsim_requirer_interface.py
@@ -44,6 +44,7 @@ class TestFivegRFSIMRequires:
                     }
                 },
                 "get-rfsim-information-invalid": {"params": {}},
+                "set-rfsim-information": {"params": {}},
             },
         )
 
@@ -249,7 +250,7 @@ class TestFivegRFSIMRequires:
             ),
         ],
     )
-    def test_given_invalid_remote_databag_when_get_rfsim_information_is_called_then_none_is_retrieved(  # noqa: E501
+    def test_given_invalid_remote_databag_when_get_rfsim_information_is_called_then_none_is_retrieved(
         self, remote_data
     ):
         fiveg_rfsim_relation = testing.Relation(
@@ -263,9 +264,7 @@ class TestFivegRFSIMRequires:
         )
         self.ctx.run(self.ctx.on.action("get-rfsim-information-invalid", params={}), state_in)
 
-    def test_given_rfsim_relation_does_not_exist_when_get_rfsim_information_then_none_is_retrieved(
-        self,
-    ):  # noqa: E501
+    def test_given_rfsim_relation_does_not_exist_when_get_rfsim_information_then_none_is_retrieved(self):
         state_in = testing.State(relations=[], leader=True)
 
         self.ctx.run(self.ctx.on.action("get-rfsim-information-invalid", params={}), state_in)
@@ -274,3 +273,14 @@ class TestFivegRFSIMRequires:
         state_in = testing.State(relations=[], leader=False)
 
         self.ctx.run(self.ctx.on.action("get-rfsim-information-invalid", params={}), state_in)
+
+    def test_given_fiveg_rfsim_relation_created_when_set_rfsim_information_then_correct_api_version_is_set(self):
+        fiveg_rfsim_relation = testing.Relation(
+            endpoint="fiveg_rfsim",
+            interface="fiveg_rfsim",
+        )
+        state_in = testing.State(
+            leader=True,
+            relations=[fiveg_rfsim_relation],
+        )
+        self.ctx.run(self.ctx.on.action("set-rfsim-information", params={}), state_in)

--- a/tests/unit/lib/charms/oai_ran_du/v0/test_fiveg_rfsim_requirer_interface.py
+++ b/tests/unit/lib/charms/oai_ran_du/v0/test_fiveg_rfsim_requirer_interface.py
@@ -250,7 +250,7 @@ class TestFivegRFSIMRequires:
             ),
         ],
     )
-    def test_given_invalid_remote_databag_when_get_rfsim_information_is_called_then_none_is_retrieved(
+    def test_given_invalid_remote_databag_when_get_rfsim_information_is_called_then_none_is_retrieved(  # noqa: E501
         self, remote_data
     ):
         fiveg_rfsim_relation = testing.Relation(
@@ -264,7 +264,9 @@ class TestFivegRFSIMRequires:
         )
         self.ctx.run(self.ctx.on.action("get-rfsim-information-invalid", params={}), state_in)
 
-    def test_given_rfsim_relation_does_not_exist_when_get_rfsim_information_then_none_is_retrieved(self):
+    def test_given_rfsim_relation_does_not_exist_when_get_rfsim_information_then_none_is_retrieved(
+        self,
+    ):
         state_in = testing.State(relations=[], leader=True)
 
         self.ctx.run(self.ctx.on.action("get-rfsim-information-invalid", params={}), state_in)
@@ -274,7 +276,9 @@ class TestFivegRFSIMRequires:
 
         self.ctx.run(self.ctx.on.action("get-rfsim-information-invalid", params={}), state_in)
 
-    def test_given_fiveg_rfsim_relation_created_when_set_rfsim_information_then_correct_api_version_is_set(self):
+    def test_given_fiveg_rfsim_relation_created_when_set_rfsim_information_then_correct_api_version_is_set(  # noqa: E501
+        self,
+    ):
         fiveg_rfsim_relation = testing.Relation(
             endpoint="fiveg_rfsim",
             interface="fiveg_rfsim",


### PR DESCRIPTION
# Description

Adds `fiveg_rfsim` requirer method for setting the App relation data. It should be used by the Requirer to push the API version to the relation data bag.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library