### PR TITLE
fix: Workaround for SSB calculation in n79

### DIFF
--- a/src/du_parameters/absolute_freq_ssb.py
+++ b/src/du_parameters/absolute_freq_ssb.py
@@ -35,6 +35,19 @@ def get_absolute_frequency_ssb(center_freq: Frequency) -> ARFCN:
     """
     try:
         gscn = GSCN.from_frequency(center_freq)
+
+        # TODO: This is a workaround for n79, it will requires future redesign
+        # n79 needs the GSCN on a raster of 16, so we take the remainder of the
+        # division with 16, and if it is lower than 8, subtract it from the GSCN.
+        # Otherwise, we add its difference from 16 to the GSCN. This will give
+        # a GSCN that is divisible by 16.
+        if center_freq >= Frequency.from_mhz(4400) and center_freq <= Frequency.from_mhz(5000):
+            modulo = gscn % 16
+            if modulo < 8:
+                gscn = gscn - modulo
+            else:
+                gscn = gscn + (16 - modulo)
+
         adjusted_frequency = gscn.to_frequency()
         afrcn = ARFCN.from_frequency(adjusted_frequency)
         logger.info(

--- a/src/du_parameters/frequency.py
+++ b/src/du_parameters/frequency.py
@@ -519,6 +519,24 @@ class GSCN:
             return GSCN(round(self._channel / other))  # type: ignore[operator]
         raise NotImplementedError(f"Unsupported type for division: {type(other).__name__}")
 
+    def __mod__(self, other: Any) -> int:
+        """Calculate modulo between GSCN and other GSCN or integer.
+
+        Args:
+            other (Any): The value to divide by.
+
+        Returns:
+            int: Remainder of the division
+
+        Raises:
+            NotImplementedError: If the other value is not an GSCN or int.
+        """
+        if isinstance(other, GSCN):
+            return self._channel % other._channel
+        if isinstance(other, int):
+            return self._channel % other
+        raise NotImplementedError(f"Unsupported type for modulo: {type(other).__name__}")
+
     def to_frequency(self) -> Frequency:
         """Calculate the frequency based on GSCN.
 

--- a/tests/unit/test_absolute_freq_ssb.py
+++ b/tests/unit/test_absolute_freq_ssb.py
@@ -51,6 +51,7 @@ class TestAbsoluteFrequencySSB:
             (20, 4110),
             (1000, 199950),
             (25000, 2029052),
+            (4900, 726432),
         ],
     )
     def test_get_absolute_frequency_ssb_when_center_frequency_given_then_return_expected_result(


### PR DESCRIPTION
# Description

This is a workaround for the SSB calculation in band n79. In case of a bandwidth of 40MHz or higher, the GSCN must be on a raster of 16. Under this bandwidth, it can be on a raster of 1.

This quick fix checks if the center frequency is in the range of n79 and forces the GSCN selection on a raster of 16. I added a comment that we should redesign this in the future, as the current fix is a bit naive.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library