### PR TITLE
fix: Fix coreset0 configuration on n79

### DIFF
--- a/src/templates/du.conf.j2
+++ b/src/templates/du.conf.j2
@@ -42,6 +42,12 @@ gNBs =
         # force_256qam_off: disable 256 QAM
         force_256qam_off = 1;
 
+    pdcch_ConfigSIB1 = (
+      {
+        controlResourceSetZero = 5;
+        searchSpaceZero = 0;
+      }
+    );
     servingCellConfigCommon = (
     {
       physCellId                                                    = 0;
@@ -77,7 +83,7 @@ gNBs =
       # pdcch-ConfigCommon
       # initialDLBWPcontrolResourceSetZero:BWP that contains all NR channels that are necessary
       # to conclude the initial access procedure
-      initialDLBWPcontrolResourceSetZero                              = 12;
+      initialDLBWPcontrolResourceSetZero                              = 5;
       initialDLBWPsearchSpaceZero                                     = 0;
 
       # uplinkConfigCommon

--- a/tests/unit/resources/expected_config.conf
+++ b/tests/unit/resources/expected_config.conf
@@ -35,6 +35,12 @@ gNBs =
         # force_256qam_off: disable 256 QAM
         force_256qam_off = 1;
 
+    pdcch_ConfigSIB1 = (
+      {
+        controlResourceSetZero = 5;
+        searchSpaceZero = 0;
+      }
+    );
     servingCellConfigCommon = (
     {
       physCellId                                                    = 0;
@@ -70,7 +76,7 @@ gNBs =
       # pdcch-ConfigCommon
       # initialDLBWPcontrolResourceSetZero:BWP that contains all NR channels that are necessary
       # to conclude the initial access procedure
-      initialDLBWPcontrolResourceSetZero                              = 12;
+      initialDLBWPcontrolResourceSetZero                              = 5;
       initialDLBWPsearchSpaceZero                                     = 0;
 
       # uplinkConfigCommon

--- a/tests/unit/resources/expected_multiple_plmns_config.conf
+++ b/tests/unit/resources/expected_multiple_plmns_config.conf
@@ -47,6 +47,12 @@ gNBs =
         # force_256qam_off: disable 256 QAM
         force_256qam_off = 1;
 
+    pdcch_ConfigSIB1 = (
+      {
+        controlResourceSetZero = 5;
+        searchSpaceZero = 0;
+      }
+    );
     servingCellConfigCommon = (
     {
       physCellId                                                    = 0;
@@ -82,7 +88,7 @@ gNBs =
       # pdcch-ConfigCommon
       # initialDLBWPcontrolResourceSetZero:BWP that contains all NR channels that are necessary
       # to conclude the initial access procedure
-      initialDLBWPcontrolResourceSetZero                              = 12;
+      initialDLBWPcontrolResourceSetZero                              = 5;
       initialDLBWPsearchSpaceZero                                     = 0;
 
       # uplinkConfigCommon

--- a/tests/unit/resources/expected_rfsim_mode_config.conf
+++ b/tests/unit/resources/expected_rfsim_mode_config.conf
@@ -35,6 +35,12 @@ gNBs =
         # force_256qam_off: disable 256 QAM
         force_256qam_off = 1;
 
+    pdcch_ConfigSIB1 = (
+      {
+        controlResourceSetZero = 5;
+        searchSpaceZero = 0;
+      }
+    );
     servingCellConfigCommon = (
     {
       physCellId                                                    = 0;
@@ -70,7 +76,7 @@ gNBs =
       # pdcch-ConfigCommon
       # initialDLBWPcontrolResourceSetZero:BWP that contains all NR channels that are necessary
       # to conclude the initial access procedure
-      initialDLBWPcontrolResourceSetZero                              = 12;
+      initialDLBWPcontrolResourceSetZero                              = 5;
       initialDLBWPsearchSpaceZero                                     = 0;
 
       # uplinkConfigCommon


### PR DESCRIPTION
# Description

This fixes the Coreset0 configuration when operating on n79. I tested this with the B210 operating on n79 and a Quectel module.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library