### PR TITLE
feat: Adds support for 2x2 MIMO

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -94,6 +94,11 @@ config:
       description: | 
         The distance between two adjacent sub-carriers given in kHz. 
         As FR1 5G spectrum supports 15, 30, 60 kHz sub-carrier spacing, it should be one of these values.
+    use-mimo:
+      type: boolean
+      default: false
+      description: |
+        When set to true enabled support for 2x2 MIMO.
 parts:
   charm:
     source: .

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -98,7 +98,7 @@ config:
       type: boolean
       default: false
       description: |
-        When set to true enabled support for 2x2 MIMO.
+        When set to true enables support for 2x2 MIMO.
 parts:
   charm:
     source: .

--- a/src/charm.py
+++ b/src/charm.py
@@ -317,6 +317,7 @@ class OAIRANDUOperator(CharmBase):
             tac=remote_network_config.tac,
             plmns=remote_network_config.plmns,
             simulation_mode=self._charm_config.simulation_mode,
+            use_mimo=self._charm_config.use_mimo,
             frequency_band=self._charm_config.frequency_band,
             sub_carrier_spacing=_get_numerology(self._charm_config.sub_carrier_spacing),
             absolute_frequency_ssb=get_absolute_frequency_ssb(self._charm_config.center_frequency),
@@ -535,6 +536,7 @@ def _render_config_file(
     tac: int,
     plmns: List[PLMNConfig],
     simulation_mode: bool,
+    use_mimo: bool,
     frequency_band: int,
     sub_carrier_spacing: int,
     absolute_frequency_ssb: ARFCN,
@@ -556,6 +558,7 @@ def _render_config_file(
         tac: Tracking Area Code
         plmns: list of PLMN
         simulation_mode: Run DU in simulation mode
+        use_mimo: When True enables 2x2 MIMO
         frequency_band: Frequency band of the DU
         sub_carrier_spacing: Subcarrier spacing of the DU
         absolute_frequency_ssb: Absolute frequency of the SSB
@@ -579,6 +582,7 @@ def _render_config_file(
         tac=tac,
         plmn_list=plmns,
         simulation_mode=simulation_mode,
+        use_mimo=use_mimo,
         frequencyBand=frequency_band,
         subcarrierSpacing=sub_carrier_spacing,
         absoluteFrequencySSB=absolute_frequency_ssb,

--- a/src/charm_config.py
+++ b/src/charm_config.py
@@ -195,6 +195,7 @@ class DUConfig(BaseModel):  # pylint: disable=too-few-public-methods
     center_frequency: str = Field(
         description="Center frequency as an integer or a float wrapped as str."
     )
+    use_mimo: bool = False
 
     @field_validator("f1_ip_address", mode="before")
     @classmethod
@@ -369,6 +370,7 @@ class CharmConfig:
     sub_carrier_spacing: Frequency
     bandwidth: Frequency
     center_frequency: Frequency
+    use_mimo: bool
 
     def __init__(self, *, du_config: DUConfig):
         """Initialize a new instance of the CharmConfig class.
@@ -386,6 +388,7 @@ class CharmConfig:
         self.sub_carrier_spacing = Frequency.from_khz(du_config.sub_carrier_spacing)
         self.bandwidth = Frequency.from_mhz(du_config.bandwidth)
         self.center_frequency = Frequency.from_mhz(du_config.center_frequency)
+        self.use_mimo = du_config.use_mimo
 
     @classmethod
     def from_charm(

--- a/src/templates/du.conf.j2
+++ b/src/templates/du.conf.j2
@@ -34,13 +34,15 @@ gNBs =
         );
         nr_cellid        = 12345678L;
         min_rxtxtime     = 6;
-
-        # do_CSIRS: 1= active if 2x2 MIMO, otherwise not considered. Suggestion, let it active
+        {%- if use_mimo %}
+        pdsch_AntennaPorts_XP                                     = 2;
+        pusch_AntennaPorts                                        = 2;
+        do_CSIRS                                                  = 1;
+        do_SRS                                                    = 1;
+        {%- else %}
         do_CSIRS                                                  = 0;
         do_SRS                                                    = 0;
-
-        # force_256qam_off: disable 256 QAM
-        force_256qam_off = 1;
+        {%- endif %}
 
     pdcch_ConfigSIB1 = (
       {
@@ -280,10 +282,10 @@ RUs =
         local_rf                      = "yes"
 
         # nb_tx: 1 means SISO, 2 means MIMO
-        nb_tx                         = 1
+        nb_tx                         = {% if use_mimo %}2{% else %}1{% endif %}
 
         # nb_rx: 1 means SISO, 2 means MIMO
-        nb_rx                         = 1
+        nb_rx                         = {% if use_mimo %}2{% else %}1{% endif %}
 
         # att_tx: ranges 6-10 if the UE is close to the B210 antennas. Leave 0 otherwise
         att_tx                        = 12;
@@ -296,7 +298,6 @@ RUs =
         max_pdschReferenceSignalPower = -27;
         max_rxgain                    = 114;
         eNB_instances                 = [0];
-        bf_weights                    = [0x00007fff, 0x0000, 0x0000, 0x0000];
         clock_src                     = "internal";
     }
 );

--- a/tests/unit/resources/expected_mimo_config.conf
+++ b/tests/unit/resources/expected_mimo_config.conf
@@ -27,8 +27,10 @@ gNBs =
         );
         nr_cellid        = 12345678L;
         min_rxtxtime     = 6;
-        do_CSIRS                                                  = 0;
-        do_SRS                                                    = 0;
+        pdsch_AntennaPorts_XP                                     = 2;
+        pusch_AntennaPorts                                        = 2;
+        do_CSIRS                                                  = 1;
+        do_SRS                                                    = 1;
 
     pdcch_ConfigSIB1 = (
       {
@@ -268,10 +270,10 @@ RUs =
         local_rf                      = "yes"
 
         # nb_tx: 1 means SISO, 2 means MIMO
-        nb_tx                         = 1
+        nb_tx                         = 2
 
         # nb_rx: 1 means SISO, 2 means MIMO
-        nb_rx                         = 1
+        nb_rx                         = 2
 
         # att_tx: ranges 6-10 if the UE is close to the B210 antennas. Leave 0 otherwise
         att_tx                        = 12;

--- a/tests/unit/resources/expected_multiple_plmns_config.conf
+++ b/tests/unit/resources/expected_multiple_plmns_config.conf
@@ -39,13 +39,8 @@ gNBs =
         );
         nr_cellid        = 12345678L;
         min_rxtxtime     = 6;
-
-        # do_CSIRS: 1= active if 2x2 MIMO, otherwise not considered. Suggestion, let it active
         do_CSIRS                                                  = 0;
         do_SRS                                                    = 0;
-
-        # force_256qam_off: disable 256 QAM
-        force_256qam_off = 1;
 
     pdcch_ConfigSIB1 = (
       {
@@ -301,7 +296,6 @@ RUs =
         max_pdschReferenceSignalPower = -27;
         max_rxgain                    = 114;
         eNB_instances                 = [0];
-        bf_weights                    = [0x00007fff, 0x0000, 0x0000, 0x0000];
         clock_src                     = "internal";
     }
 );

--- a/tests/unit/resources/expected_rfsim_mode_config.conf
+++ b/tests/unit/resources/expected_rfsim_mode_config.conf
@@ -27,13 +27,8 @@ gNBs =
         );
         nr_cellid        = 12345678L;
         min_rxtxtime     = 6;
-
-        # do_CSIRS: 1= active if 2x2 MIMO, otherwise not considered. Suggestion, let it active
         do_CSIRS                                                  = 0;
         do_SRS                                                    = 0;
-
-        # force_256qam_off: disable 256 QAM
-        force_256qam_off = 1;
 
     pdcch_ConfigSIB1 = (
       {
@@ -289,7 +284,6 @@ RUs =
         max_pdschReferenceSignalPower = -27;
         max_rxgain                    = 114;
         eNB_instances                 = [0];
-        bf_weights                    = [0x00007fff, 0x0000, 0x0000, 0x0000];
         clock_src                     = "internal";
     }
 );

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -223,9 +223,7 @@ class TestCharmConfigure(DUFixtures):
 
             self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
 
-            with open(
-                    "tests/unit/resources/expected_mimo_config.conf"
-            ) as expected_config_file:
+            with open("tests/unit/resources/expected_mimo_config.conf") as expected_config_file:
                 expected_config = expected_config_file.read()
 
             with open(f"{temp_dir}/du.conf") as generated_config_file:


### PR DESCRIPTION
# Description

Adds support for 2x2 MIMO.
New config option `use_mimo` is now available for enabling MIMO support.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library