### PR TITLE
chore: Replaces fiveg_rfsim relation with fiveg_rf_config

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -59,27 +59,27 @@ jobs:
     secrets:
       CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}
 
-  fiveg-rfsim-lib-needs-publishing:
+  fiveg-rf-config-lib-needs-publishing:
     runs-on: ubuntu-22.04
     outputs:
-      needs-publishing: ${{ steps.changes.outputs.fiveg_rfsim }}
+      needs-publishing: ${{ steps.changes.outputs.fiveg_rf_config }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
         id: changes
         with:
           filters: |
-            fiveg_rfsim:
-              - 'lib/charms/oai_ran_du_k8s/v0/fiveg_rfsim.py'
+            fiveg_rf_config:
+              - 'lib/charms/oai_ran_du_k8s/v0/fiveg_rf_config.py'
 
-  publish-fiveg-rfsim-lib:
+  publish-fiveg-rf-config-lib:
     name: Publish Lib
     needs:
       - publish-charm
-      - fiveg-rfsim-lib-needs-publishing
+      - fiveg-rf-config-lib-needs-publishing
     if: ${{ github.ref_name == 'main' }}
     uses: canonical/sdcore-github-workflows/.github/workflows/publish-lib.yaml@v2.3.2
     with:
-      lib-name: "charms.oai_ran_du_k8s.v0.fiveg_rfsim"
+      lib-name: "charms.oai_ran_du_k8s.v0.fiveg_rf_config"
     secrets:
       CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 *.charm
 .tox/
 .coverage
+coverage.xml
 __pycache__/
 *.py[cod]
 .idea

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -34,8 +34,8 @@ resources:
     upstream-source: ghcr.io/canonical/oai-ran-du:2.2.0
 
 provides:
-  fiveg_rfsim:
-    interface: fiveg_rfsim
+  fiveg_rf_config:
+    interface: fiveg_rf_config
 
 requires:
   fiveg_f1:

--- a/lib/charms/oai_ran_du_k8s/v0/fiveg_rf_config.py
+++ b/lib/charms/oai_ran_du_k8s/v0/fiveg_rf_config.py
@@ -1,11 +1,11 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Library for the `fiveg_rfsim` relation.
+"""Library for the `fiveg_rf_config` relation.
 
-This library contains the Requires and Provides classes for handling the `fiveg_rfsim` interface.
+This library contains the Requires and Provides classes for handling the `fiveg-rf-config` interface.
 
-The purpose of this library is to relate two charms to pass the network configuration data required to start the RF simulation.
+The purpose of this library is to pass the Radio Frequency (RF) configuration data required to establish communication between two charms implementing the `fiveg-rf-config` interface over a real or simulated RF medium.
 In particular the RF SIM address, Network Slice Type (SST), Slice Differentiator (SD), RF band, downlink frequency, carrier bandwidth, numerology and the number of the first usable subcarrier will be passed through the interface.
 In the Telco world this will typically be charms implementing the DU (Distributed Unit) and the UE (User equipment).
 
@@ -13,7 +13,7 @@ In the Telco world this will typically be charms implementing the DU (Distribute
 From a charm directory, fetch the library using `charmcraft`:
 
 ```shell
-charmcraft fetch-lib charms.oai_ran_du_k8s.v0.fiveg_rfsim
+charmcraft fetch-lib charms.oai_ran_du_k8s.v0.fiveg_rf_config
 ```
 
 Add the following libraries to the charm's `requirements.txt` file:
@@ -30,10 +30,10 @@ Example:
 from ops import main
 from ops.charm import CharmBase, RelationChangedEvent
 
-from charms.oai_ran_du_k8s.v0.fiveg_rfsim import RFSIMProvides
+from charms.oai_ran_du_k8s.v0.fiveg_rf_config import RFConfigProvides
 
 
-class DummyFivegRFSIMProviderCharm(CharmBase):
+class DummyFivegRFConfigProviderCharm(CharmBase):
 
     RFSIM_ADDRESS = "192.168.70.130"
     SST = 1
@@ -46,14 +46,14 @@ class DummyFivegRFSIMProviderCharm(CharmBase):
 
     def __init__(self, *args):
         super().__init__(*args)
-        self.rfsim_provider = RFSIMProvides(self, "fiveg_rfsim")
+        self.rf_config_provider = RFConfigProvides(self, "fiveg_rf_config")
         self.framework.observe(
-            self.on.fiveg_rfsim_relation_changed, self._on_fiveg_rfsim_relation_changed
+            self.on.fiveg_rf_config_relation_changed, self._on_fiveg_rf_config_relation_changed
         )
 
-    def _on_fiveg_rfsim_relation_changed(self, event: RelationChangedEvent):
+    def _on_fiveg_rf_config_relation_changed(self, event: RelationChangedEvent):
         if self.unit.is_leader():
-            self.rfsim_provider.set_rfsim_information(
+            self.rf_config_provider.set_rf_config_information(
                 version=0,
                 rfsim_address=self.RFSIM_ADDRESS,
                 sst=self.SST,
@@ -67,11 +67,11 @@ class DummyFivegRFSIMProviderCharm(CharmBase):
 
 
 if __name__ == "__main__":
-    main(DummyFivegRFSIMProviderCharm)
+    main(DummyFivegRFConfigProviderCharm)
 ```
 
 ### Requirer charm
-The requirer charm is the one requiring the RF simulator information.
+The requirer charm is the one requiring the RF configuration information.
 Typically, this will be the UE charm.
 
 Example:
@@ -80,21 +80,21 @@ Example:
 from ops import main
 from ops.charm import CharmBase, RelationChangedEvent
 
-from charms.oai_ran_du_k8s.v0.fiveg_rfsim import RFSIMRequires
+from charms.oai_ran_du_k8s.v0.fiveg_rf_config import RFConfigRequires
 
 logger = logging.getLogger(__name__)
 
 
-class DummyFivegRFSIMRequires(CharmBase):
+class DummyFivegRFConfigRequires(CharmBase):
 
     def __init__(self, *args):
         super().__init__(*args)
-        self.rfsim_requirer = RFSIMRequires(self, "fiveg_rfsim")
+        self.rf_config_requirer = RFConfigRequires(self, "fiveg_rf_config")
         self.framework.observe(
-            self.on.fiveg_rfsim_relation_changed, self._on_fiveg_rfsim_relation_changed
+            self.on.fiveg_rf_config_relation_changed, self._on_fiveg_rf_config_relation_changed
         )
 
-    def _on_fiveg_rfsim_relation_changed(self, event: RelationChangedEvent):
+    def _on_fiveg_rf_config_relation_changed(self, event: RelationChangedEvent):
         provider_rfsim_address = event.rfsim_address
         provider_sst = event.sst
         provider_sd = event.sd
@@ -107,7 +107,7 @@ class DummyFivegRFSIMRequires(CharmBase):
 
 
 if __name__ == "__main__":
-    main(DummyFivegRFSIMRequires)
+    main(DummyFivegRFConfigRequires)
 ```
 
 """
@@ -124,19 +124,19 @@ from pydantic import BaseModel, Field, IPvAnyAddress, ValidationError
 
 
 # The unique Charmhub library identifier, never change it
-LIBID = "e5d421b1edce4e8b8b3632d55869117c"
+LIBID = "86b25cb056d849a1aeab703c98e81820"
 
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 1
 
 
 logger = logging.getLogger(__name__)
 
-"""Schemas definition for the provider and requirer sides of the `fiveg_rfsim` interface.
+"""Schemas definition for the provider and requirer sides of the `fiveg_rf_config` interface.
 It exposes two interface_tester.schema_base.DataBagSchema subclasses called:
 - ProviderSchema
 - RequirerSchema
@@ -163,15 +163,16 @@ Examples:
 
 
 class ProviderAppData(BaseModel):
-    """Provider app data for fiveg_rfsim."""
+    """Provider app data for fiveg_rf_config."""
 
     version: int = Field(
         description="Interface version",
         examples=[0, 1, 2, 3],
         ge=0,
     )
-    rfsim_address: IPvAnyAddress = Field(
+    rfsim_address: Optional[IPvAnyAddress] = Field(
         description="RF simulator service address which is equal to DU pod ip",
+        default=None,
         examples=["192.168.70.130"],
     )
     sst: int = Field(
@@ -222,13 +223,13 @@ class ProviderAppData(BaseModel):
 
 
 class ProviderSchema(DataBagSchema):
-    """Provider schema for the fiveg_rfsim interface."""
+    """Provider schema for the fiveg_rf_config relation."""
 
     app_data: ProviderAppData
 
 
 class RequirerAppData(BaseModel):
-    """Requirer app data for fiveg_rfsim."""
+    """Requirer app data for fiveg_rf_config."""
 
     version: int = Field(
         description="Interface version",
@@ -238,7 +239,7 @@ class RequirerAppData(BaseModel):
 
 
 class RequirerSchema(DataBagSchema):
-    """Requirer schema for the fiveg_rfsim interface."""
+    """Requirer schema for the fiveg_rf_config relation."""
 
     app_data: RequirerAppData
 
@@ -277,16 +278,16 @@ def requirer_data_is_valid(data: Dict[str, Any]) -> bool:
         return False
 
 
-class FivegRFSIMError(Exception):
-    """Custom error class for the `fiveg_rfsim` library."""
+class FivegRFConfigError(Exception):
+    """Custom error class for the `fiveg_rf_config` library."""
 
     def __init__(self, message: str):
         self.message = message
         super().__init__(self.message)
 
 
-class RFSIMProvides(Object):
-    """Class to be instantiated by the charm providing relation using the `fiveg_rfsim` interface."""
+class RFConfigProvides(Object):
+    """Class to be instantiated by the charm providing the `fiveg_rf_config` relation."""
 
     def __init__(self, charm: CharmBase, relation_name: str):
         """Init."""
@@ -294,9 +295,9 @@ class RFSIMProvides(Object):
         self.relation_name = relation_name
         self.charm = charm
 
-    def set_rfsim_information(
+    def set_rf_config_information(
         self,
-        rfsim_address: str,
+        rfsim_address: Optional[str],
         sst: int,
         sd: Optional[int],
         band: int,
@@ -305,10 +306,10 @@ class RFSIMProvides(Object):
         numerology: int,
         start_subcarrier: int,
     ) -> None:
-        """Push the information about the RFSIM interface in the application relation data.
+        """Push the information about the RF configuration in the application relation data.
 
         Args:
-            rfsim_address (str): rfsim service address which is equal to DU pod ip.
+            rfsim_address (Optional[str]): rfsim service address which is equal to DU Pod IP
             sst (int): Slice/Service Type
             sd (Optional[int]): Slice Differentiator
             band (int): Valid 5G band
@@ -318,28 +319,27 @@ class RFSIMProvides(Object):
             start_subcarrier (int): First usable subcarrier
         """
         if not self.charm.unit.is_leader():
-            raise FivegRFSIMError("Unit must be leader to set application relation data.")
+            raise FivegRFConfigError("Unit must be leader to set application relation data.")
         relations = self.model.relations[self.relation_name]
         if not relations:
-            raise FivegRFSIMError(f"Relation {self.relation_name} not created yet.")
+            raise FivegRFConfigError(f"Relation {self.relation_name} not created yet.")
         if not provider_data_is_valid(
-            {
-                "version": str(LIBAPI),
-                "rfsim_address": rfsim_address,
-                "sst": sst,
-                "sd": sd,
-                "band": band,
-                "dl_freq": dl_freq,
-                "carrier_bandwidth": carrier_bandwidth,
-                "numerology": numerology,
-                "start_subcarrier": start_subcarrier,
-            }
+                {
+                    "version": str(LIBAPI),
+                    "rfsim_address": rfsim_address,
+                    "sst": sst,
+                    "sd": sd,
+                    "band": band,
+                    "dl_freq": dl_freq,
+                    "carrier_bandwidth": carrier_bandwidth,
+                    "numerology": numerology,
+                    "start_subcarrier": start_subcarrier,
+                }
         ):
-            raise FivegRFSIMError("Invalid relation data")
+            raise FivegRFConfigError("Invalid relation data")
         for relation in relations:
             data = {
                 "version": str(LIBAPI),
-                "rfsim_address": rfsim_address,
                 "sst": str(sst),
                 "band": str(band),
                 "dl_freq": str(dl_freq),
@@ -347,6 +347,8 @@ class RFSIMProvides(Object):
                 "numerology": str(numerology),
                 "start_subcarrier": str(start_subcarrier),
             }
+            if rfsim_address is not None:
+                data["rfsim_address"] = str(rfsim_address)
             if sd is not None:
                 data["sd"] = str(sd)
             relation.data[self.charm.app].update(data)
@@ -356,8 +358,8 @@ class RFSIMProvides(Object):
         return LIBAPI
 
 
-class RFSIMRequires(Object):
-    """Class to be instantiated by the charm requiring relation using the `fiveg_rfsim` interface."""
+class RFConfigRequires(Object):
+    """Class to be instantiated by the charm requiring the `fiveg_rf_config` relation."""
 
     def __init__(self, charm: CharmBase, relation_name: str):
         """Init."""
@@ -370,7 +372,7 @@ class RFSIMRequires(Object):
         """Return interface version used by the provider.
 
         Returns:
-            Optional[int]: The `fiveg_rfsim` interface version used by the provider.
+            Optional[int]: The `fiveg_rf_config` interface version used by the provider.
         """
         return self._get_provider_interface_version()
 
@@ -381,7 +383,7 @@ class RFSIMRequires(Object):
         Returns:
             Optional[IPvAnyAddress]: rfsim address which is equal to DU pod ip.
         """
-        if remote_app_relation_data := self.get_provider_rfsim_information():
+        if remote_app_relation_data := self.get_provider_rf_config_information():
             return remote_app_relation_data.rfsim_address
         return None
 
@@ -392,7 +394,7 @@ class RFSIMRequires(Object):
         Returns:
             Optional[int]: sst (Network Slice Service Type)
         """
-        if remote_app_relation_data := self.get_provider_rfsim_information():
+        if remote_app_relation_data := self.get_provider_rf_config_information():
             return remote_app_relation_data.sst
         return None
 
@@ -403,7 +405,7 @@ class RFSIMRequires(Object):
         Returns:
            Optional[int] : sd (Network Slice Differentiator)
         """
-        if remote_app_relation_data := self.get_provider_rfsim_information():
+        if remote_app_relation_data := self.get_provider_rf_config_information():
             return remote_app_relation_data.sd
         return None
 
@@ -414,7 +416,7 @@ class RFSIMRequires(Object):
         Returns:
            Optional[int] : band (RF Band number)
         """
-        if remote_app_relation_data := self.get_provider_rfsim_information():
+        if remote_app_relation_data := self.get_provider_rf_config_information():
             return remote_app_relation_data.band
         return None
 
@@ -425,7 +427,7 @@ class RFSIMRequires(Object):
         Returns:
            Optional[int] : dl_freq (Downlink frequency)
         """
-        if remote_app_relation_data := self.get_provider_rfsim_information():
+        if remote_app_relation_data := self.get_provider_rf_config_information():
             return remote_app_relation_data.dl_freq
         return None
 
@@ -436,7 +438,7 @@ class RFSIMRequires(Object):
         Returns:
            Optional[int] : carrier_bandwidth (carrier bandwidth)
         """
-        if remote_app_relation_data := self.get_provider_rfsim_information():
+        if remote_app_relation_data := self.get_provider_rf_config_information():
             return remote_app_relation_data.carrier_bandwidth
         return None
 
@@ -447,7 +449,7 @@ class RFSIMRequires(Object):
         Returns:
            Optional[int] : numerology
         """
-        if remote_app_relation_data := self.get_provider_rfsim_information():
+        if remote_app_relation_data := self.get_provider_rf_config_information():
             return remote_app_relation_data.numerology
         return None
 
@@ -458,7 +460,7 @@ class RFSIMRequires(Object):
         Returns:
            Optional[int] : start_subcarrier
         """
-        if remote_app_relation_data := self.get_provider_rfsim_information():
+        if remote_app_relation_data := self.get_provider_rf_config_information():
             return remote_app_relation_data.start_subcarrier
         return None
 
@@ -466,7 +468,7 @@ class RFSIMRequires(Object):
         """Get provider interface version.
 
         Returns:
-            Optional[int]: The `fiveg_rfsim` interface version used by the provider.
+            Optional[int]: The `fiveg_rf_config` interface version used by the provider.
         """
         relation = self.model.get_relation(self.relation_name)
         if not relation:
@@ -478,10 +480,10 @@ class RFSIMRequires(Object):
         try:
             return int(dict(relation.data[relation.app]).get("version", ""))
         except ValueError:
-            logger.error("Invalid or missing `fiveg_rfsim` provider interface version.")
+            logger.error("Invalid or missing `fiveg_rf_config` provider interface version.")
             return None
 
-    def get_provider_rfsim_information(
+    def get_provider_rf_config_information(
         self, relation: Optional[Relation] = None
     ) -> Optional[ProviderAppData]:
         """Get relation data for the remote application.
@@ -515,11 +517,8 @@ class RFSIMRequires(Object):
             remote_app_relation_data["start_subcarrier"] = int(
                 remote_app_relation_data.get("start_subcarrier", "")
             )
-        except ValueError as err:
-            logger.error("Invalid relation data: %s: %s", remote_app_relation_data, str(err))
-            return None
-
-        try:
+            if rfsim_address := remote_app_relation_data.get("rfsim_address"):
+                remote_app_relation_data["rfsim_address"] = str(rfsim_address)
             if sd := remote_app_relation_data.get("sd"):
                 remote_app_relation_data["sd"] = int(sd)
         except ValueError as err:
@@ -533,15 +532,15 @@ class RFSIMRequires(Object):
             return None
         return provider_app_data
 
-    def set_rfsim_information(self) -> None:
-        """Push the information about the `fiveg_rfsim` interface version used by the Requirer."""
+    def set_rf_config_information(self) -> None:
+        """Push the information about the `fiveg_rf_config` interface version used by the Requirer."""
         if not self.charm.unit.is_leader():
-            raise FivegRFSIMError("Unit must be leader to set application relation data.")
+            raise FivegRFConfigError("Unit must be leader to set application relation data.")
         relations = self.model.relations[self.relation_name]
         if not relations:
-            raise FivegRFSIMError(f"Relation {self.relation_name} not created yet.")
+            raise FivegRFConfigError(f"Relation {self.relation_name} not created yet.")
         if not requirer_data_is_valid({"version": str(LIBAPI)}):
-            raise FivegRFSIMError("Invalid relation data")
+            raise FivegRFConfigError("Invalid relation data")
         for relation in relations:
             data = {"version": str(LIBAPI)}
             relation.data[self.charm.app].update(data)

--- a/lib/charms/oai_ran_du_k8s/v0/fiveg_rf_config.py
+++ b/lib/charms/oai_ran_du_k8s/v0/fiveg_rf_config.py
@@ -324,17 +324,17 @@ class RFConfigProvides(Object):
         if not relations:
             raise FivegRFConfigError(f"Relation {self.relation_name} not created yet.")
         if not provider_data_is_valid(
-                {
-                    "version": str(LIBAPI),
-                    "rfsim_address": rfsim_address,
-                    "sst": sst,
-                    "sd": sd,
-                    "band": band,
-                    "dl_freq": dl_freq,
-                    "carrier_bandwidth": carrier_bandwidth,
-                    "numerology": numerology,
-                    "start_subcarrier": start_subcarrier,
-                }
+            {
+                "version": str(LIBAPI),
+                "rfsim_address": rfsim_address,
+                "sst": sst,
+                "sd": sd,
+                "band": band,
+                "dl_freq": dl_freq,
+                "carrier_bandwidth": carrier_bandwidth,
+                "numerology": numerology,
+                "start_subcarrier": start_subcarrier,
+            }
         ):
             raise FivegRFConfigError("Invalid relation data")
         for relation in relations:

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -8,7 +8,7 @@ output "app_name" {
 
 output "provides" {
   value = {
-    "fiveg_rfsim" = "fiveg_rfsim"
+    "fiveg_rf_config" = "fiveg_rf_config"
   }
 }
 

--- a/tests/unit/fixtures.py
+++ b/tests/unit/fixtures.py
@@ -35,8 +35,8 @@ class DUFixtures:
         "charm.F1Requires.get_provider_f1_information",
     )
     patcher_f1_requires_set_f1_information = patch("charm.F1Requires.set_f1_information")
-    patcher_rfsim_provides_set_rfsim_information = patch(
-        "charm.RFSIMProvides.set_rfsim_information"
+    patcher_rf_config_provides_set_rf_config_information = patch(
+        "charm.RFConfigProvides.set_rf_config_information"
     )
 
     @pytest.fixture(autouse=True)
@@ -47,8 +47,8 @@ class DUFixtures:
         self.mock_k8s_multus = DUFixtures.patcher_k8s_multus.start().return_value
         self.mock_f1_get_remote_data = DUFixtures.patcher_f1_get_remote_data.start()
         self.mock_f1_set_information = DUFixtures.patcher_f1_requires_set_f1_information.start()
-        self.mock_rfsim_set_information = (
-            DUFixtures.patcher_rfsim_provides_set_rfsim_information.start()
+        self.mock_rf_config_set_information = (
+            DUFixtures.patcher_rf_config_provides_set_rf_config_information.start()
         )
         yield
         request.addfinalizer(self.tearDown)

--- a/tests/unit/lib/charms/oai_ran_du/v0/test_charms/test_provider_charm/src/charm.py
+++ b/tests/unit/lib/charms/oai_ran_du/v0/test_charms/test_provider_charm/src/charm.py
@@ -6,22 +6,22 @@ import logging
 from ops import main
 from ops.charm import ActionEvent, CharmBase
 
-from lib.charms.oai_ran_du_k8s.v0.fiveg_rfsim import RFSIMProvides
+from lib.charms.oai_ran_du_k8s.v0.fiveg_rf_config import RFConfigProvides
 
 logger = logging.getLogger(__name__)
 
 
-class DummyFivegRFSIMProviderCharm(CharmBase):
-    """Dummy charm implementing the provider side of the fiveg_rfsim interface."""
+class DummyFivegRFConfigProviderCharm(CharmBase):
+    """Dummy charm implementing the provider side of the fiveg_rf_config relation."""
 
     def __init__(self, *args):
         super().__init__(*args)
-        self.rfsim_provider = RFSIMProvides(self, "fiveg_rfsim")
+        self.rf_config_provider = RFConfigProvides(self, "fiveg_rf_config")
         self.framework.observe(
-            self.on.set_rfsim_information_action, self._on_set_rfsim_information_action
+            self.on.set_rf_config_information_action, self._on_set_rf_config_information_action
         )
 
-    def _on_set_rfsim_information_action(self, event: ActionEvent):
+    def _on_set_rf_config_information_action(self, event: ActionEvent):
         rfsim_address = event.params.get("rfsim_address", "")
         sst = event.params.get("sst", "")
         sd = event.params.get("sd", "")
@@ -30,8 +30,8 @@ class DummyFivegRFSIMProviderCharm(CharmBase):
         carrier_bandwidth = event.params.get("carrier_bandwidth", "")
         numerology = event.params.get("numerology", "")
         start_subcarrier = event.params.get("start_subcarrier", "")
-        self.rfsim_provider.set_rfsim_information(
-            rfsim_address=rfsim_address,
+        self.rf_config_provider.set_rf_config_information(
+            rfsim_address=rfsim_address if rfsim_address else None,
             sst=int(sst),
             sd=int(sd) if sd else None,
             band=int(band),
@@ -43,4 +43,4 @@ class DummyFivegRFSIMProviderCharm(CharmBase):
 
 
 if __name__ == "__main__":
-    main(DummyFivegRFSIMProviderCharm)
+    main(DummyFivegRFConfigProviderCharm)

--- a/tests/unit/lib/charms/oai_ran_du/v0/test_charms/test_requirer_charm/src/charm.py
+++ b/tests/unit/lib/charms/oai_ran_du/v0/test_charms/test_requirer_charm/src/charm.py
@@ -5,28 +5,28 @@
 from ops import main
 from ops.charm import ActionEvent, CharmBase
 
-from lib.charms.oai_ran_du_k8s.v0.fiveg_rfsim import LIBAPI, ProviderAppData, RFSIMRequires
+from lib.charms.oai_ran_du_k8s.v0.fiveg_rf_config import LIBAPI, ProviderAppData, RFConfigRequires
 
 
-class DummyFivegRFSIMRequires(CharmBase):
-    """Dummy charm implementing the requirer side of the fiveg_rfsim interface."""
+class DummyFivegRFConfigRequires(CharmBase):
+    """Dummy charm implementing the requirer side of the fiveg_rf_config relation."""
 
     def __init__(self, *args):
         super().__init__(*args)
-        self.rfsim_requirer = RFSIMRequires(self, "fiveg_rfsim")
+        self.rf_config_requirer = RFConfigRequires(self, "fiveg_rf_config")
         self.framework.observe(
-            self.on.get_rfsim_information_action, self._on_get_rfsim_information_action
+            self.on.get_rf_config_information_action, self._on_get_rf_config_information_action
         )
         self.framework.observe(
-            self.on.get_rfsim_information_invalid_action,
-            self._on_get_rfsim_information_invalid_action,
+            self.on.get_rf_config_information_invalid_action,
+            self._on_get_rf_config_information_invalid_action,
         )
         self.framework.observe(
-            self.on.set_rfsim_information_action,
-            self._on_set_rfsim_information_action,
+            self.on.set_rf_config_information_action,
+            self._on_set_rf_config_information_action,
         )
 
-    def _on_get_rfsim_information_action(self, event: ActionEvent):
+    def _on_get_rf_config_information_action(self, event: ActionEvent):
         version = event.params.get("expected_version", "")
         rfsim_address = event.params.get("expected_rfsim_address", "")
         sst = event.params.get("expected_sst", "")
@@ -38,7 +38,6 @@ class DummyFivegRFSIMRequires(CharmBase):
         start_subcarrier = event.params.get("expected_start_subcarrier", "")
         data = {
             "version": version,
-            "rfsim_address": rfsim_address,
             "sst": int(sst),
             "band": int(band),
             "dl_freq": int(dl_freq),
@@ -46,21 +45,23 @@ class DummyFivegRFSIMRequires(CharmBase):
             "numerology": int(numerology),
             "start_subcarrier": int(start_subcarrier),
         }
+        if rfsim_address:
+            data["rfsim_address"] = str(rfsim_address)
         if sd:
             data["sd"] = int(sd)
         provider_app_data = ProviderAppData(**data)
-        assert provider_app_data == self.rfsim_requirer.get_provider_rfsim_information()
+        assert provider_app_data == self.rf_config_requirer.get_provider_rf_config_information()
 
-    def _on_get_rfsim_information_invalid_action(self, event: ActionEvent):
-        assert self.rfsim_requirer.get_provider_rfsim_information() is None
+    def _on_get_rf_config_information_invalid_action(self, event: ActionEvent):
+        assert self.rf_config_requirer.get_provider_rf_config_information() is None
 
-    def _on_set_rfsim_information_action(self, event: ActionEvent):
-        self.rfsim_requirer.set_rfsim_information()
-        relation = self.model.get_relation(self.rfsim_requirer.relation_name)
+    def _on_set_rf_config_information_action(self, event: ActionEvent):
+        self.rf_config_requirer.set_rf_config_information()
+        relation = self.model.get_relation(self.rf_config_requirer.relation_name)
         if not relation:
             assert False
         assert int(relation.data[self.app].get("version", "")) == LIBAPI
 
 
 if __name__ == "__main__":
-    main(DummyFivegRFSIMRequires)
+    main(DummyFivegRFConfigRequires)

--- a/tests/unit/lib/charms/oai_ran_du/v0/test_fiveg_rf_config_provider_interface.py
+++ b/tests/unit/lib/charms/oai_ran_du/v0/test_fiveg_rf_config_provider_interface.py
@@ -4,8 +4,9 @@
 import pytest
 from ops import testing
 
+from charm import RF_CONFIG_RELATION_NAME
 from tests.unit.lib.charms.oai_ran_du.v0.test_charms.test_provider_charm.src.charm import (
-    DummyFivegRFSIMProviderCharm,
+    DummyFivegRFConfigProviderCharm,
 )
 
 VALID_RFSIM_ADDRESS = "192.168.70.130"
@@ -18,17 +19,17 @@ VALID_NUMEROLOGY = "1"
 VALID_START_SUBCARRIER = "541"
 
 
-class TestFivegRFSIMProvides:
+class TestFivegRFConfigProvides:
     @pytest.fixture(autouse=True)
     def context(self):
         self.ctx = testing.Context(
-            charm_type=DummyFivegRFSIMProviderCharm,
+            charm_type=DummyFivegRFConfigProviderCharm,
             meta={
-                "name": "rfsim-provider-charm",
-                "provides": {"fiveg_rfsim": {"interface": "fiveg_rfsim"}},
+                "name": "rf-config-provider-charm",
+                "provides": {RF_CONFIG_RELATION_NAME: {"interface": RF_CONFIG_RELATION_NAME}},
             },
             actions={
-                "set-rfsim-information": {
+                "set-rf-config-information": {
                     "params": {
                         "rfsim_address": {"type": "string"},
                         "sst": {"type": "string"},
@@ -40,7 +41,7 @@ class TestFivegRFSIMProvides:
                         "start_subcarrier": {"type": "string"},
                     }
                 },
-                "set-rfsim-information-as-string": {
+                "set-rf-config-information-as-string": {
                     "params": {
                         "rfsim_address": {"type": "string"},
                         "sst": {"type": "string"},
@@ -55,15 +56,15 @@ class TestFivegRFSIMProvides:
             },
         )
 
-    def test_given_valid_rfsim_interface_data_when_set_rfsim_information_then_rfsim_address_is_pushed_to_the_relation_databag(  # noqa: E501
+    def test_given_valid_rf_config_relation_data_when_set_rf_config_information_then_rfsim_address_is_pushed_to_the_relation_databag(  # noqa: E501
         self,
     ):
-        fiveg_rfsim_relation = testing.Relation(
-            endpoint="fiveg_rfsim",
-            interface="fiveg_rfsim",
+        fiveg_rf_config_relation = testing.Relation(
+            endpoint=RF_CONFIG_RELATION_NAME,
+            interface=RF_CONFIG_RELATION_NAME,
         )
         state_in = testing.State(
-            relations=[fiveg_rfsim_relation],
+            relations=[fiveg_rf_config_relation],
             leader=True,
         )
         params = {
@@ -78,10 +79,10 @@ class TestFivegRFSIMProvides:
         }
 
         state_out = self.ctx.run(
-            self.ctx.on.action("set-rfsim-information", params=params), state_in
+            self.ctx.on.action("set-rf-config-information", params=params), state_in
         )
 
-        relation = state_out.get_relation(fiveg_rfsim_relation.id)
+        relation = state_out.get_relation(fiveg_rf_config_relation.id)
         assert relation.local_app_data["rfsim_address"] == VALID_RFSIM_ADDRESS
         assert relation.local_app_data["sst"] == VALID_SST
         assert relation.local_app_data["sd"] == VALID_SD
@@ -91,15 +92,15 @@ class TestFivegRFSIMProvides:
         assert relation.local_app_data["numerology"] == VALID_NUMEROLOGY
         assert relation.local_app_data["start_subcarrier"] == VALID_START_SUBCARRIER
 
-    def test_given_no_sd_when_set_rfsim_information_then_rfsim_data_is_pushed_to_the_relation_databag_without_sd(  # noqa: E501
+    def test_given_no_sd_when_set_rf_config_information_then_rf_config_data_is_pushed_to_the_relation_databag_without_sd(  # noqa: E501
         self,
     ):
-        fiveg_rfsim_relation = testing.Relation(
-            endpoint="fiveg_rfsim",
-            interface="fiveg_rfsim",
+        fiveg_rf_config_relation = testing.Relation(
+            endpoint=RF_CONFIG_RELATION_NAME,
+            interface=RF_CONFIG_RELATION_NAME,
         )
         state_in = testing.State(
-            relations=[fiveg_rfsim_relation],
+            relations=[fiveg_rf_config_relation],
             leader=True,
         )
         params = {
@@ -113,10 +114,10 @@ class TestFivegRFSIMProvides:
         }
 
         state_out = self.ctx.run(
-            self.ctx.on.action("set-rfsim-information", params=params), state_in
+            self.ctx.on.action("set-rf-config-information", params=params), state_in
         )
 
-        relation = state_out.get_relation(fiveg_rfsim_relation.id)
+        relation = state_out.get_relation(fiveg_rf_config_relation.id)
         assert relation.local_app_data["rfsim_address"] == VALID_RFSIM_ADDRESS
         assert relation.local_app_data["sst"] == VALID_SST
         assert relation.local_app_data.get("sd") is None
@@ -126,26 +127,17 @@ class TestFivegRFSIMProvides:
         assert relation.local_app_data["numerology"] == VALID_NUMEROLOGY
         assert relation.local_app_data["start_subcarrier"] == VALID_START_SUBCARRIER
 
-    @pytest.mark.parametrize(
-        "rfsim_address",
-        [
-            pytest.param("1111", id="invalid_rfsim_address"),
-            pytest.param("", id="empty_rfsim_address"),
-        ],
-    )
-    def test_given_invalid_rfsim_address_when_set_rfsim_information_then_error_is_raised(
-        self, rfsim_address
-    ):
-        fiveg_rfsim_relation = testing.Relation(
-            endpoint="fiveg_rfsim",
-            interface="fiveg_rfsim",
+    def test_given_invalid_rfsim_address_when_set_rf_config_information_then_error_is_raised(self):
+        fiveg_rf_config_relation = testing.Relation(
+            endpoint=RF_CONFIG_RELATION_NAME,
+            interface=RF_CONFIG_RELATION_NAME,
         )
         state_in = testing.State(
-            relations=[fiveg_rfsim_relation],
+            relations=[fiveg_rf_config_relation],
             leader=True,
         )
         params = {
-            "rfsim_address": rfsim_address,
+            "rfsim_address": "1111",
             "sst": VALID_SST,
             "sd": VALID_SD,
             "band": VALID_BAND,
@@ -156,7 +148,7 @@ class TestFivegRFSIMProvides:
         }
 
         with pytest.raises(Exception) as e:
-            self.ctx.run(self.ctx.on.action("set-rfsim-information", params=params), state_in)
+            self.ctx.run(self.ctx.on.action("set-rf-config-information", params=params), state_in)
 
         assert "Invalid relation data" in str(e.value)
 
@@ -169,15 +161,15 @@ class TestFivegRFSIMProvides:
             pytest.param("256", VALID_SD, id="too_large_sst"),
         ],
     )
-    def test_given_invalid_sst_and_sd_when_set_rfsim_information_then_error_is_raised(
+    def test_given_invalid_sst_and_sd_when_set_rf_config_information_then_error_is_raised(
         self, sst, sd
     ):
-        fiveg_rfsim_relation = testing.Relation(
-            endpoint="fiveg_rfsim",
-            interface="fiveg_rfsim",
+        fiveg_rf_config_relation = testing.Relation(
+            endpoint=RF_CONFIG_RELATION_NAME,
+            interface=RF_CONFIG_RELATION_NAME,
         )
         state_in = testing.State(
-            relations=[fiveg_rfsim_relation],
+            relations=[fiveg_rf_config_relation],
             leader=True,
         )
         params = {
@@ -192,7 +184,7 @@ class TestFivegRFSIMProvides:
         }
 
         with pytest.raises(Exception) as e:
-            self.ctx.run(self.ctx.on.action("set-rfsim-information", params=params), state_in)
+            self.ctx.run(self.ctx.on.action("set-rf-config-information", params=params), state_in)
 
         assert "Invalid relation data" in str(e.value)
 
@@ -203,13 +195,13 @@ class TestFivegRFSIMProvides:
             pytest.param("0", id="rf_band_is_0"),
         ],
     )
-    def test_given_invalid_rf_band_when_set_rfsim_information_then_error_is_raised(self, band):
-        fiveg_rfsim_relation = testing.Relation(
-            endpoint="fiveg_rfsim",
-            interface="fiveg_rfsim",
+    def test_given_invalid_rf_band_when_set_rf_config_information_then_error_is_raised(self, band):
+        fiveg_rf_config_relation = testing.Relation(
+            endpoint=RF_CONFIG_RELATION_NAME,
+            interface=RF_CONFIG_RELATION_NAME,
         )
         state_in = testing.State(
-            relations=[fiveg_rfsim_relation],
+            relations=[fiveg_rf_config_relation],
             leader=True,
         )
         params = {
@@ -224,7 +216,7 @@ class TestFivegRFSIMProvides:
         }
 
         with pytest.raises(Exception) as e:
-            self.ctx.run(self.ctx.on.action("set-rfsim-information", params=params), state_in)
+            self.ctx.run(self.ctx.on.action("set-rf-config-information", params=params), state_in)
 
         assert "Invalid relation data" in str(e.value)
 
@@ -237,13 +229,15 @@ class TestFivegRFSIMProvides:
             pytest.param("409999999", id="dl_freq_upper_edge"),
         ],
     )
-    def test_given_invalid_dl_freq_when_set_rfsim_information_then_error_is_raised(self, dl_freq):
-        fiveg_rfsim_relation = testing.Relation(
-            endpoint="fiveg_rfsim",
-            interface="fiveg_rfsim",
+    def test_given_invalid_dl_freq_when_set_rf_config_information_then_error_is_raised(
+        self, dl_freq
+    ):
+        fiveg_rf_config_relation = testing.Relation(
+            endpoint=RF_CONFIG_RELATION_NAME,
+            interface=RF_CONFIG_RELATION_NAME,
         )
         state_in = testing.State(
-            relations=[fiveg_rfsim_relation],
+            relations=[fiveg_rf_config_relation],
             leader=True,
         )
         params = {
@@ -258,7 +252,7 @@ class TestFivegRFSIMProvides:
         }
 
         with pytest.raises(Exception) as e:
-            self.ctx.run(self.ctx.on.action("set-rfsim-information", params=params), state_in)
+            self.ctx.run(self.ctx.on.action("set-rf-config-information", params=params), state_in)
 
         assert "Invalid relation data" in str(e.value)
 
@@ -270,15 +264,15 @@ class TestFivegRFSIMProvides:
             pytest.param("274", id="carrier_bandwidth_above_273"),
         ],
     )
-    def test_given_invalid_carrier_bandwidth_when_set_rfsim_information_then_error_is_raised(
+    def test_given_invalid_carrier_bandwidth_when_set_rf_config_information_then_error_is_raised(
         self, carrier_bandwidth
     ):
-        fiveg_rfsim_relation = testing.Relation(
-            endpoint="fiveg_rfsim",
-            interface="fiveg_rfsim",
+        fiveg_rf_config_relation = testing.Relation(
+            endpoint=RF_CONFIG_RELATION_NAME,
+            interface=RF_CONFIG_RELATION_NAME,
         )
         state_in = testing.State(
-            relations=[fiveg_rfsim_relation],
+            relations=[fiveg_rf_config_relation],
             leader=True,
         )
         params = {
@@ -293,7 +287,7 @@ class TestFivegRFSIMProvides:
         }
 
         with pytest.raises(Exception) as e:
-            self.ctx.run(self.ctx.on.action("set-rfsim-information", params=params), state_in)
+            self.ctx.run(self.ctx.on.action("set-rf-config-information", params=params), state_in)
 
         assert "Invalid relation data" in str(e.value)
 
@@ -304,15 +298,15 @@ class TestFivegRFSIMProvides:
             pytest.param("7", id="numerology_above_6"),
         ],
     )
-    def test_given_invalid_numerology_when_set_rfsim_information_then_error_is_raised(
+    def test_given_invalid_numerology_when_set_rf_config_information_then_error_is_raised(
         self, numerology
     ):
-        fiveg_rfsim_relation = testing.Relation(
-            endpoint="fiveg_rfsim",
-            interface="fiveg_rfsim",
+        fiveg_rf_config_relation = testing.Relation(
+            endpoint=RF_CONFIG_RELATION_NAME,
+            interface=RF_CONFIG_RELATION_NAME,
         )
         state_in = testing.State(
-            relations=[fiveg_rfsim_relation],
+            relations=[fiveg_rf_config_relation],
             leader=True,
         )
         params = {
@@ -327,17 +321,19 @@ class TestFivegRFSIMProvides:
         }
 
         with pytest.raises(Exception) as e:
-            self.ctx.run(self.ctx.on.action("set-rfsim-information", params=params), state_in)
+            self.ctx.run(self.ctx.on.action("set-rf-config-information", params=params), state_in)
 
         assert "Invalid relation data" in str(e.value)
 
-    def test_given_invalid_start_subcarrier_when_set_rfsim_information_then_error_is_raised(self):
-        fiveg_rfsim_relation = testing.Relation(
-            endpoint="fiveg_rfsim",
-            interface="fiveg_rfsim",
+    def test_given_invalid_start_subcarrier_when_set_rf_config_information_then_error_is_raised(
+        self,
+    ):
+        fiveg_rf_config_relation = testing.Relation(
+            endpoint=RF_CONFIG_RELATION_NAME,
+            interface=RF_CONFIG_RELATION_NAME,
         )
         state_in = testing.State(
-            relations=[fiveg_rfsim_relation],
+            relations=[fiveg_rf_config_relation],
             leader=True,
         )
         params = {
@@ -352,20 +348,20 @@ class TestFivegRFSIMProvides:
         }
 
         with pytest.raises(Exception) as e:
-            self.ctx.run(self.ctx.on.action("set-rfsim-information", params=params), state_in)
+            self.ctx.run(self.ctx.on.action("set-rf-config-information", params=params), state_in)
 
         assert "Invalid relation data" in str(e.value)
 
-    def test_given_unit_is_not_leader_when_fiveg_rfsim_relation_joined_then_data_is_not_in_application_databag(  # noqa: E501
+    def test_given_unit_is_not_leader_when_fiveg_rf_config_relation_joined_then_data_is_not_in_application_databag(  # noqa: E501
         self,
     ):
-        fiveg_rfsim_relation = testing.Relation(
-            endpoint="fiveg_rfsim",
-            interface="fiveg_rfsim",
+        fiveg_rf_config_relation = testing.Relation(
+            endpoint=RF_CONFIG_RELATION_NAME,
+            interface=RF_CONFIG_RELATION_NAME,
         )
         state_in = testing.State(
             leader=False,
-            relations=[fiveg_rfsim_relation],
+            relations=[fiveg_rf_config_relation],
         )
         params = {
             "rfsim_address": VALID_RFSIM_ADDRESS,
@@ -379,11 +375,11 @@ class TestFivegRFSIMProvides:
         }
 
         with pytest.raises(Exception) as e:
-            self.ctx.run(self.ctx.on.action("set-rfsim-information", params=params), state_in)
+            self.ctx.run(self.ctx.on.action("set-rf-config-information", params=params), state_in)
 
         assert "Unit must be leader" in str(e.value)
 
-    def test_given_rfsim_relation_does_not_exist_when_set_rfsim_information_then_error_is_raised(  # noqa: E501
+    def test_given_rfsim_relation_does_not_exist_when_set_rf_config_information_then_error_is_raised(  # noqa: E501
         self,
     ):
         state_in = testing.State(relations=[], leader=True)
@@ -399,6 +395,6 @@ class TestFivegRFSIMProvides:
         }
 
         with pytest.raises(Exception) as e:
-            self.ctx.run(self.ctx.on.action("set-rfsim-information", params=params), state_in)
+            self.ctx.run(self.ctx.on.action("set-rf-config-information", params=params), state_in)
 
-        assert "Relation fiveg_rfsim not created yet." in str(e.value)
+        assert "Relation fiveg_rf_config not created yet." in str(e.value)

--- a/tests/unit/lib/charms/oai_ran_du/v0/test_fiveg_rf_config_requirer_interface.py
+++ b/tests/unit/lib/charms/oai_ran_du/v0/test_fiveg_rf_config_requirer_interface.py
@@ -5,8 +5,9 @@
 import pytest
 from ops import testing
 
+from charm import RF_CONFIG_RELATION_NAME
 from tests.unit.lib.charms.oai_ran_du.v0.test_charms.test_requirer_charm.src.charm import (
-    DummyFivegRFSIMRequires,
+    DummyFivegRFConfigRequires,
 )
 
 VALID_INTERFACE_VERSION = "0"
@@ -20,17 +21,17 @@ VALID_NUMEROLOGY = "1"
 VALID_START_SUBCARRIER = "541"
 
 
-class TestFivegRFSIMRequires:
+class TestFivegRFConfigRequires:
     @pytest.fixture(autouse=True)
     def context(self):
         self.ctx = testing.Context(
-            charm_type=DummyFivegRFSIMRequires,
+            charm_type=DummyFivegRFConfigRequires,
             meta={
-                "name": "rfsim-requirer-charm",
-                "requires": {"fiveg_rfsim": {"interface": "fiveg_rfsim"}},
+                "name": "rf-config-requirer-charm",
+                "requires": {RF_CONFIG_RELATION_NAME: {"interface": RF_CONFIG_RELATION_NAME}},
             },
             actions={
-                "get-rfsim-information": {
+                "get-rf-config-information": {
                     "params": {
                         "expected_version": {"type": "integer"},
                         "expected_rfsim_address": {"type": "string"},
@@ -43,8 +44,8 @@ class TestFivegRFSIMRequires:
                         "expected_start_subcarrier": {"type": "integer"},
                     }
                 },
-                "get-rfsim-information-invalid": {"params": {}},
-                "set-rfsim-information": {"params": {}},
+                "get-rf-config-information-invalid": {"params": {}},
+                "set-rf-config-information": {"params": {}},
             },
         )
 
@@ -77,6 +78,28 @@ class TestFivegRFSIMRequires:
             pytest.param(
                 {
                     "version": VALID_INTERFACE_VERSION,
+                    "sst": VALID_SST,
+                    "sd": VALID_SD,
+                    "band": VALID_BAND,
+                    "dl_freq": VALID_DL_FREQ,
+                    "carrier_bandwidth": VALID_CARRIER_BANDWIDTH,
+                    "numerology": VALID_NUMEROLOGY,
+                    "start_subcarrier": VALID_START_SUBCARRIER,
+                },
+                int(VALID_INTERFACE_VERSION),
+                "",
+                int(VALID_SST),
+                int(VALID_SD),
+                int(VALID_BAND),
+                int(VALID_DL_FREQ),
+                int(VALID_CARRIER_BANDWIDTH),
+                int(VALID_NUMEROLOGY),
+                int(VALID_START_SUBCARRIER),
+                id="empty_rfsim_address",
+            ),
+            pytest.param(
+                {
+                    "version": VALID_INTERFACE_VERSION,
                     "rfsim_address": VALID_RFSIM_ADDRESS,
                     "sst": VALID_SST,
                     "band": VALID_BAND,
@@ -98,7 +121,7 @@ class TestFivegRFSIMRequires:
             ),
         ],
     )
-    def test_given_valid_rfsim_information_in_relation_data_when_get_rfsim_information_is_called_then_information_is_returned(  # noqa: E501
+    def test_given_valid_rf_config_information_in_relation_data_when_get_rf_config_information_is_called_then_information_is_returned(  # noqa: E501
         self,
         remote_data,
         expected_version,
@@ -111,14 +134,14 @@ class TestFivegRFSIMRequires:
         expected_numerology,
         expected_start_subcarrier,
     ):
-        fiveg_rfsim_relation = testing.Relation(
-            endpoint="fiveg_rfsim",
-            interface="fiveg_rfsim",
+        fiveg_rf_config_relation = testing.Relation(
+            endpoint=RF_CONFIG_RELATION_NAME,
+            interface=RF_CONFIG_RELATION_NAME,
             remote_app_data=remote_data,
         )
         state_in = testing.State(
             leader=True,
-            relations=[fiveg_rfsim_relation],
+            relations=[fiveg_rf_config_relation],
         )
         params = {
             "expected_version": expected_version,
@@ -131,7 +154,7 @@ class TestFivegRFSIMRequires:
             "expected_numerology": expected_numerology,
             "expected_start_subcarrier": expected_start_subcarrier,
         }
-        self.ctx.run(self.ctx.on.action("get-rfsim-information", params=params), state_in)
+        self.ctx.run(self.ctx.on.action("get-rf-config-information", params=params), state_in)
 
     @pytest.mark.parametrize(
         "remote_data",
@@ -250,41 +273,41 @@ class TestFivegRFSIMRequires:
             ),
         ],
     )
-    def test_given_invalid_remote_databag_when_get_rfsim_information_is_called_then_none_is_retrieved(  # noqa: E501
+    def test_given_invalid_remote_databag_when_get_rf_config_information_is_called_then_none_is_retrieved(  # noqa: E501
         self, remote_data
     ):
-        fiveg_rfsim_relation = testing.Relation(
-            endpoint="fiveg_rfsim",
-            interface="fiveg_rfsim",
+        fiveg_rf_config_relation = testing.Relation(
+            endpoint=RF_CONFIG_RELATION_NAME,
+            interface=RF_CONFIG_RELATION_NAME,
             remote_app_data=remote_data,
         )
         state_in = testing.State(
             leader=True,
-            relations=[fiveg_rfsim_relation],
+            relations=[fiveg_rf_config_relation],
         )
-        self.ctx.run(self.ctx.on.action("get-rfsim-information-invalid", params={}), state_in)
+        self.ctx.run(self.ctx.on.action("get-rf-config-information-invalid", params={}), state_in)
 
-    def test_given_rfsim_relation_does_not_exist_when_get_rfsim_information_then_none_is_retrieved(
+    def test_given_rf_config_relation_does_not_exist_when_get_rf_config_information_then_none_is_retrieved(  # noqa: E501
         self,
     ):
         state_in = testing.State(relations=[], leader=True)
 
-        self.ctx.run(self.ctx.on.action("get-rfsim-information-invalid", params={}), state_in)
+        self.ctx.run(self.ctx.on.action("get-rf-config-information-invalid", params={}), state_in)
 
-    def test_given_charm_is_not_leader_when_get_rfsim_information_then_none_is_retrieved(self):
+    def test_given_charm_is_not_leader_when_get_rf_config_information_then_none_is_retrieved(self):
         state_in = testing.State(relations=[], leader=False)
 
-        self.ctx.run(self.ctx.on.action("get-rfsim-information-invalid", params={}), state_in)
+        self.ctx.run(self.ctx.on.action("get-rf-config-information-invalid", params={}), state_in)
 
-    def test_given_fiveg_rfsim_relation_created_when_set_rfsim_information_then_correct_api_version_is_set(  # noqa: E501
+    def test_given_fiveg_rf_config_relation_created_when_set_rf_config_information_then_correct_api_version_is_set(  # noqa: E501
         self,
     ):
-        fiveg_rfsim_relation = testing.Relation(
-            endpoint="fiveg_rfsim",
-            interface="fiveg_rfsim",
+        fiveg_rf_config_relation = testing.Relation(
+            endpoint=RF_CONFIG_RELATION_NAME,
+            interface=RF_CONFIG_RELATION_NAME,
         )
         state_in = testing.State(
             leader=True,
-            relations=[fiveg_rfsim_relation],
+            relations=[fiveg_rf_config_relation],
         )
-        self.ctx.run(self.ctx.on.action("set-rfsim-information", params={}), state_in)
+        self.ctx.run(self.ctx.on.action("set-rf-config-information", params={}), state_in)

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -8,10 +8,11 @@ from ipaddress import IPv4Address
 
 import pytest
 from charms.oai_ran_cu_k8s.v0.fiveg_f1 import PLMNConfig, ProviderAppData
-from charms.oai_ran_du_k8s.v0.fiveg_rfsim import LIBAPI
+from charms.oai_ran_du_k8s.v0.fiveg_rf_config import LIBAPI
 from ops import testing
 from ops.pebble import Layer
 
+from charm import RF_CONFIG_RELATION_NAME
 from tests.unit.fixtures import F1_PROVIDER_DATA, F1_PROVIDER_DATA_WITH_SD, DUFixtures
 
 F1_PROVIDER_DATA_MULTIPLE_PLMNS = ProviderAppData(
@@ -29,7 +30,7 @@ SAMPLE_CONFIG = {
     "sub-carrier-spacing": 15,
     "center-frequency": "3500",
 }
-INVALID_FIVEG_RFSIM_API_VERSION = str(LIBAPI + 1)
+INVALID_FIVEG_RF_CONFIG_API_VERSION = str(LIBAPI + 1)
 
 
 class TestCharmConfigure(DUFixtures):
@@ -422,7 +423,7 @@ class TestCharmConfigure(DUFixtures):
 
             self.mock_f1_set_information.assert_called_once_with(port=2152)
 
-    def test_given_charm_is_configured_rfsim_address_is_not_available_and_f1_provider_data_is_available_when_rfsim_relation_is_joined_then_rfsim_information_is_not_published(  # noqa: E501
+    def test_given_charm_is_configured_rfsim_address_is_not_available_and_f1_provider_data_is_available_when_rf_config_relation_is_joined_then_rf_config_information_is_not_published(  # noqa: E501
         self,
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -434,9 +435,9 @@ class TestCharmConfigure(DUFixtures):
                 endpoint="fiveg_f1",
                 interface="fiveg_f1",
             )
-            rfsim_relation = testing.Relation(
-                endpoint="fiveg_rfsim",
-                interface="fiveg_rfsim",
+            rf_config_relation = testing.Relation(
+                endpoint=RF_CONFIG_RELATION_NAME,
+                interface=RF_CONFIG_RELATION_NAME,
             )
             config_mount = testing.Mount(
                 source=temp_dir,
@@ -451,7 +452,7 @@ class TestCharmConfigure(DUFixtures):
             )
             state_in = testing.State(
                 leader=True,
-                relations=[f1_relation, rfsim_relation],
+                relations=[f1_relation, rf_config_relation],
                 containers=[container],
                 model=testing.Model(name="whatever"),
                 config={**SAMPLE_CONFIG, "simulation-mode": True},
@@ -459,9 +460,9 @@ class TestCharmConfigure(DUFixtures):
 
             self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
 
-            self.mock_rfsim_set_information.assert_not_called()
+            self.mock_rf_config_set_information.assert_not_called()
 
-    def test_given_charm_is_configured_running_and_f1_provider_data_is_not_available_when_rfsim_relation_is_joined_then_rfsim_information_is_not_published(  # noqa: E501
+    def test_given_charm_is_configured_running_and_f1_provider_data_is_not_available_when_rf_config_relation_is_joined_then_rf_config_information_is_not_published(  # noqa: E501
         self,
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -473,9 +474,9 @@ class TestCharmConfigure(DUFixtures):
                 endpoint="fiveg_f1",
                 interface="fiveg_f1",
             )
-            rfsim_relation = testing.Relation(
-                endpoint="fiveg_rfsim",
-                interface="fiveg_rfsim",
+            rf_config_relation = testing.Relation(
+                endpoint=RF_CONFIG_RELATION_NAME,
+                interface=RF_CONFIG_RELATION_NAME,
             )
             config_mount = testing.Mount(
                 source=temp_dir,
@@ -490,7 +491,7 @@ class TestCharmConfigure(DUFixtures):
             )
             state_in = testing.State(
                 leader=True,
-                relations=[f1_relation, rfsim_relation],
+                relations=[f1_relation, rf_config_relation],
                 containers=[container],
                 model=testing.Model(name="whatever"),
                 config={**SAMPLE_CONFIG, "simulation-mode": True},
@@ -498,9 +499,9 @@ class TestCharmConfigure(DUFixtures):
 
             self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
 
-            self.mock_rfsim_set_information.assert_not_called()
+            self.mock_rf_config_set_information.assert_not_called()
 
-    def test_given_charm_is_configured_running_and_f1_provider_data_includes_multiple_plmns_when_rfsim_relation_is_joined_then_rfsim_information_is_published_with_first_plmn_info(  # noqa: E501
+    def test_given_charm_is_configured_running_and_f1_provider_data_includes_multiple_plmns_when_rf_config_relation_is_joined_then_rf_config_information_is_published_with_first_plmn_info(  # noqa: E501
         self,
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -512,9 +513,9 @@ class TestCharmConfigure(DUFixtures):
                 endpoint="fiveg_f1",
                 interface="fiveg_f1",
             )
-            rfsim_relation = testing.Relation(
-                endpoint="fiveg_rfsim",
-                interface="fiveg_rfsim",
+            rf_config_relation = testing.Relation(
+                endpoint=RF_CONFIG_RELATION_NAME,
+                interface=RF_CONFIG_RELATION_NAME,
                 remote_app_data={"version": str(LIBAPI)},
             )
             config_mount = testing.Mount(
@@ -530,7 +531,7 @@ class TestCharmConfigure(DUFixtures):
             )
             state_in = testing.State(
                 leader=True,
-                relations=[f1_relation, rfsim_relation],
+                relations=[f1_relation, rf_config_relation],
                 containers=[container],
                 model=testing.Model(name="whatever"),
                 config={**SAMPLE_CONFIG, "simulation-mode": True},
@@ -538,7 +539,7 @@ class TestCharmConfigure(DUFixtures):
 
             self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
 
-            self.mock_rfsim_set_information.assert_called_once_with(
+            self.mock_rf_config_set_information.assert_called_once_with(
                 rfsim_address="1.2.3.4",
                 sst=12,
                 sd=None,
@@ -549,16 +550,16 @@ class TestCharmConfigure(DUFixtures):
                 start_subcarrier=525,
             )
 
-    def test_given_charm_is_configured_running_and_f1_relation_is_not_created_when_rfsim_relation_is_joined_then_rfsim_information_is_not_published(  # noqa: E501
+    def test_given_charm_is_configured_running_and_f1_relation_is_not_created_when_rf_config_relation_is_joined_then_rf_config_information_is_not_published(  # noqa: E501
         self,
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
             self.mock_du_security_context.is_privileged.return_value = True
             self.mock_du_usb_volume.is_mounted.return_value = True
             self.mock_check_output.return_value = b"1.2.3.4"
-            rfsim_relation = testing.Relation(
-                endpoint="fiveg_rfsim",
-                interface="fiveg_rfsim",
+            rf_config_relation = testing.Relation(
+                endpoint=RF_CONFIG_RELATION_NAME,
+                interface=RF_CONFIG_RELATION_NAME,
             )
             config_mount = testing.Mount(
                 source=temp_dir,
@@ -573,7 +574,7 @@ class TestCharmConfigure(DUFixtures):
             )
             state_in = testing.State(
                 leader=True,
-                relations=[rfsim_relation],
+                relations=[rf_config_relation],
                 containers=[container],
                 model=testing.Model(name="whatever"),
                 config={**SAMPLE_CONFIG, "simulation-mode": True},
@@ -581,9 +582,9 @@ class TestCharmConfigure(DUFixtures):
 
             self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
 
-            self.mock_rfsim_set_information.assert_not_called()
+            self.mock_rf_config_set_information.assert_not_called()
 
-    def test_given_charm_is_configured_running_and_f1_provider_data_is_available_with_sd_when_rfsim_relation_is_joined_then_rfsim_information_is_published_including_sd(  # noqa: E501
+    def test_given_charm_is_configured_running_and_f1_provider_data_is_available_with_sd_when_rf_config_relation_is_joined_then_rf_config_information_is_published_including_sd(  # noqa: E501
         self,
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -595,9 +596,9 @@ class TestCharmConfigure(DUFixtures):
                 endpoint="fiveg_f1",
                 interface="fiveg_f1",
             )
-            rfsim_relation = testing.Relation(
-                endpoint="fiveg_rfsim",
-                interface="fiveg_rfsim",
+            rf_config_relation = testing.Relation(
+                endpoint=RF_CONFIG_RELATION_NAME,
+                interface=RF_CONFIG_RELATION_NAME,
                 remote_app_data={"version": str(LIBAPI)},
             )
             config_mount = testing.Mount(
@@ -613,7 +614,7 @@ class TestCharmConfigure(DUFixtures):
             )
             state_in = testing.State(
                 leader=True,
-                relations=[f1_relation, rfsim_relation],
+                relations=[f1_relation, rf_config_relation],
                 containers=[container],
                 model=testing.Model(name="whatever"),
                 config={**SAMPLE_CONFIG, "simulation-mode": True},
@@ -621,7 +622,7 @@ class TestCharmConfigure(DUFixtures):
 
             self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
 
-            self.mock_rfsim_set_information.assert_called_once_with(
+            self.mock_rf_config_set_information.assert_called_once_with(
                 rfsim_address="1.2.3.4",
                 sst=1,
                 sd=1,
@@ -632,7 +633,7 @@ class TestCharmConfigure(DUFixtures):
                 start_subcarrier=525,
             )
 
-    def test_given_charm_is_configured_running_and_f1_provider_data_is_available_with_sd_when_rfsim_relation_joins_and_requirer_uses_different_api_version_then_rfsim_information_is_not_published(  # noqa: E501
+    def test_given_charm_simulation_mode_is_false_when_rf_config_relation_joined_then_rf_config_information_is_published_without_rfsim_address(  # noqa: E501
         self,
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -644,10 +645,10 @@ class TestCharmConfigure(DUFixtures):
                 endpoint="fiveg_f1",
                 interface="fiveg_f1",
             )
-            rfsim_relation = testing.Relation(
-                endpoint="fiveg_rfsim",
-                interface="fiveg_rfsim",
-                remote_app_data={"version": INVALID_FIVEG_RFSIM_API_VERSION},
+            rf_config_relation = testing.Relation(
+                endpoint=RF_CONFIG_RELATION_NAME,
+                interface=RF_CONFIG_RELATION_NAME,
+                remote_app_data={"version": str(LIBAPI)},
             )
             config_mount = testing.Mount(
                 source=temp_dir,
@@ -662,16 +663,65 @@ class TestCharmConfigure(DUFixtures):
             )
             state_in = testing.State(
                 leader=True,
-                relations=[f1_relation, rfsim_relation],
+                relations=[f1_relation, rf_config_relation],
+                containers=[container],
+                model=testing.Model(name="whatever"),
+                config={**SAMPLE_CONFIG, "simulation-mode": False},
+            )
+
+            self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
+
+            self.mock_rf_config_set_information.assert_called_once_with(
+                rfsim_address=None,
+                sst=1,
+                sd=1,
+                band=77,
+                dl_freq=3499545000,
+                carrier_bandwidth=106,
+                numerology=0,
+                start_subcarrier=525,
+            )
+
+    def test_given_charm_is_configured_running_and_f1_provider_data_is_available_with_sd_when_rf_config_relation_joins_and_requirer_uses_different_api_version_then_rf_config_information_is_not_published(  # noqa: E501
+        self,
+    ):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self.mock_du_security_context.is_privileged.return_value = True
+            self.mock_du_usb_volume.is_mounted.return_value = True
+            self.mock_f1_get_remote_data.return_value = F1_PROVIDER_DATA_WITH_SD
+            self.mock_check_output.return_value = b"1.2.3.4"
+            f1_relation = testing.Relation(
+                endpoint="fiveg_f1",
+                interface="fiveg_f1",
+            )
+            rf_config_relation = testing.Relation(
+                endpoint=RF_CONFIG_RELATION_NAME,
+                interface=RF_CONFIG_RELATION_NAME,
+                remote_app_data={"version": INVALID_FIVEG_RF_CONFIG_API_VERSION},
+            )
+            config_mount = testing.Mount(
+                source=temp_dir,
+                location="/tmp/conf",
+            )
+            container = testing.Container(
+                name="du",
+                can_connect=True,
+                mounts={
+                    "config": config_mount,
+                },
+            )
+            state_in = testing.State(
+                leader=True,
+                relations=[f1_relation, rf_config_relation],
                 containers=[container],
                 model=testing.Model(name="whatever"),
                 config={**SAMPLE_CONFIG, "simulation-mode": True},
             )
             self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
 
-            self.mock_rfsim_set_information.assert_not_called()
+            self.mock_rf_config_set_information.assert_not_called()
 
-    def test_given_charm_is_configured_running_and_f1_provider_data_is_available_with_sd_when_rfsim_relation_joins_and_requirer_uses_different_api_version_then_relevant_error_message_is_logged(  # noqa: E501
+    def test_given_charm_is_configured_running_and_f1_provider_data_is_available_with_sd_when_rf_config_relation_joins_and_requirer_uses_different_api_version_then_relevant_error_message_is_logged(  # noqa: E501
         self,
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -683,10 +733,10 @@ class TestCharmConfigure(DUFixtures):
                 endpoint="fiveg_f1",
                 interface="fiveg_f1",
             )
-            rfsim_relation = testing.Relation(
-                endpoint="fiveg_rfsim",
-                interface="fiveg_rfsim",
-                remote_app_data={"version": INVALID_FIVEG_RFSIM_API_VERSION},
+            rf_config_relation = testing.Relation(
+                endpoint=RF_CONFIG_RELATION_NAME,
+                interface=RF_CONFIG_RELATION_NAME,
+                remote_app_data={"version": INVALID_FIVEG_RF_CONFIG_API_VERSION},
             )
             config_mount = testing.Mount(
                 source=temp_dir,
@@ -701,7 +751,7 @@ class TestCharmConfigure(DUFixtures):
             )
             state_in = testing.State(
                 leader=True,
-                relations=[f1_relation, rfsim_relation],
+                relations=[f1_relation, rf_config_relation],
                 containers=[container],
                 model=testing.Model(name="whatever"),
                 config={**SAMPLE_CONFIG, "simulation-mode": True},
@@ -711,7 +761,7 @@ class TestCharmConfigure(DUFixtures):
             assert (
                 testing.JujuLogLine(
                     level="ERROR",
-                    message="Can't establish communication over the `fiveg_rfsim` "
+                    message="Can't establish communication over the `fiveg_rf_config` "
                     "interface due to version mismatch!",
                 )
                 in self.ctx.juju_log

--- a/tests/unit/test_charm_fiveg_rf_config_relation_changed.py
+++ b/tests/unit/test_charm_fiveg_rf_config_relation_changed.py
@@ -4,10 +4,11 @@
 
 import tempfile
 
-from charms.oai_ran_du_k8s.v0.fiveg_rfsim import LIBAPI
+from charms.oai_ran_du_k8s.v0.fiveg_rf_config import LIBAPI
 from ops import testing
 from ops.pebble import Layer, ServiceStatus
 
+from charm import RF_CONFIG_RELATION_NAME
 from tests.unit.fixtures import F1_PROVIDER_DATA_WITH_SD, DUFixtures
 
 SAMPLE_CONFIG = {
@@ -18,29 +19,31 @@ SAMPLE_CONFIG = {
 }
 
 
-class TestCharmFivegRFSIMRelationChanged(DUFixtures):
-    def test_given_f1_relation_exists_service_not_running_when_fiveg_rfsim_relation_changed_then_rfsim_information_is_not_in_relation_databag(  # noqa: E501
+class TestCharmFivegRFCOnfigRelationChanged(DUFixtures):
+    def test_given_f1_relation_exists_service_not_running_when_fiveg_rf_config_relation_changed_then_rf_config_information_is_not_in_relation_databag(  # noqa: E501
         self,
     ):
         f1_relation = testing.Relation(endpoint="fiveg_f1", interface="fiveg_f1")
-        fiveg_rfsim_relation = testing.Relation(endpoint="fiveg_rfsim", interface="fiveg_rfsim")
+        fiveg_rf_config_relation = testing.Relation(
+            endpoint=RF_CONFIG_RELATION_NAME, interface=RF_CONFIG_RELATION_NAME
+        )
         container = testing.Container(name="du", can_connect=True)
         state_in = testing.State(
             leader=True,
             containers=[container],
-            relations=[fiveg_rfsim_relation, f1_relation],
+            relations=[fiveg_rf_config_relation, f1_relation],
         )
         self.mock_check_output.return_value = b"1.2.3.4"
 
-        state_out = self.ctx.run(self.ctx.on.relation_changed(fiveg_rfsim_relation), state_in)
+        state_out = self.ctx.run(self.ctx.on.relation_changed(fiveg_rf_config_relation), state_in)
 
-        relation = state_out.get_relation(fiveg_rfsim_relation.id)
+        relation = state_out.get_relation(fiveg_rf_config_relation.id)
         assert relation.local_app_data == {}
 
-    def test_given_service_is_running_and_f1_relation_joined_and_remote_network_information_exists_when_fiveg_rfsim_relation_changed_then_rfsim_information_is_in_relation_databag(  # noqa: E501
+    def test_given_service_is_running_and_f1_relation_joined_and_remote_network_information_exists_when_fiveg_rf_config_relation_changed_then_rf_config_information_is_in_relation_databag(  # noqa: E501
         self,
     ):
-        DUFixtures.patcher_rfsim_provides_set_rfsim_information.stop()
+        DUFixtures.patcher_rf_config_provides_set_rf_config_information.stop()
         with tempfile.TemporaryDirectory() as temp_dir:
             self.mock_du_security_context.is_privileged.return_value = True
             self.mock_du_usb_volume.is_mounted.return_value = True
@@ -50,9 +53,9 @@ class TestCharmFivegRFSIMRelationChanged(DUFixtures):
                 endpoint="fiveg_f1",
                 interface="fiveg_f1",
             )
-            fiveg_rfsim_relation = testing.Relation(
-                endpoint="fiveg_rfsim",
-                interface="fiveg_rfsim",
+            fiveg_rf_config_relation = testing.Relation(
+                endpoint=RF_CONFIG_RELATION_NAME,
+                interface=RF_CONFIG_RELATION_NAME,
                 remote_app_data={"version": str(LIBAPI)},
             )
             config_mount = testing.Mount(
@@ -83,14 +86,16 @@ class TestCharmFivegRFSIMRelationChanged(DUFixtures):
             )
             state_in = testing.State(
                 leader=True,
-                relations=[f1_relation, fiveg_rfsim_relation],
+                relations=[f1_relation, fiveg_rf_config_relation],
                 containers=[container],
                 model=testing.Model(name="whatever"),
                 config={**SAMPLE_CONFIG, "simulation-mode": True},
             )
 
-            state_out = self.ctx.run(self.ctx.on.relation_changed(fiveg_rfsim_relation), state_in)
-            relation = state_out.get_relation(fiveg_rfsim_relation.id)
+            state_out = self.ctx.run(
+                self.ctx.on.relation_changed(fiveg_rf_config_relation), state_in
+            )
+            relation = state_out.get_relation(fiveg_rf_config_relation.id)
             assert relation.local_app_data == {
                 "version": str(LIBAPI),
                 "rfsim_address": "1.2.3.4",
@@ -103,16 +108,16 @@ class TestCharmFivegRFSIMRelationChanged(DUFixtures):
                 "start_subcarrier": "202",
             }
 
-    def test_given_given_service_is_running_and_f1_relation_does_not_exist_when_fiveg_rfsim_relation_changed_then_rfsim_information_is_not_in_relation_databag(  # noqa: E501
+    def test_given_given_service_is_running_and_f1_relation_does_not_exist_when_fiveg_rf_config_relation_changed_then_rf_config_information_is_not_in_relation_databag(  # noqa: E501
         self,
     ):
-        DUFixtures.patcher_rfsim_provides_set_rfsim_information.stop()
+        DUFixtures.patcher_rf_config_provides_set_rf_config_information.stop()
         with tempfile.TemporaryDirectory() as temp_dir:
             self.mock_du_security_context.is_privileged.return_value = True
             self.mock_check_output.return_value = b"1.2.3.4"
-            fiveg_rfsim_relation = testing.Relation(
-                endpoint="fiveg_rfsim",
-                interface="fiveg_rfsim",
+            fiveg_rf_config_relation = testing.Relation(
+                endpoint=RF_CONFIG_RELATION_NAME,
+                interface=RF_CONFIG_RELATION_NAME,
                 remote_app_data={"version": str(LIBAPI)},
             )
             config_mount = testing.Mount(
@@ -143,12 +148,14 @@ class TestCharmFivegRFSIMRelationChanged(DUFixtures):
             )
             state_in = testing.State(
                 leader=True,
-                relations=[fiveg_rfsim_relation],
+                relations=[fiveg_rf_config_relation],
                 containers=[container],
                 model=testing.Model(name="whatever"),
                 config={**SAMPLE_CONFIG, "simulation-mode": True},
             )
 
-            state_out = self.ctx.run(self.ctx.on.relation_changed(fiveg_rfsim_relation), state_in)
-            relation = state_out.get_relation(fiveg_rfsim_relation.id)
+            state_out = self.ctx.run(
+                self.ctx.on.relation_changed(fiveg_rf_config_relation), state_in
+            )
+            relation = state_out.get_relation(fiveg_rf_config_relation.id)
             assert relation.local_app_data == {}


### PR DESCRIPTION
# Description

This PR is part of a fix for [TELCO-1730](https://warthogs.atlassian.net/browse/TELCO-1730).

Changes in this PR will allow passing the RF configuration to the `fiveg_rf_config` requirer (in our case the OAI UE charm) regardless of the DU `simulation-mode` being True or False. 
The relation name no longer suggests using simulated RF medium.
The `rfsim_address` will only be passed if the `simulation-mode` config is set to True.

This is a breaking change (because of changing the relation name) and we should expect the OAI tutorials to be broken until changes are done on the UE side as well.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library

[TELCO-1730]: https://warthogs.atlassian.net/browse/TELCO-1730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ